### PR TITLE
Fase 1 – Fundamentos (Auth, RBAC, dados base)

### DIFF
--- a/backend/routes/orgs.js
+++ b/backend/routes/orgs.js
@@ -8,6 +8,10 @@ const requireRole =
   requireRoleModule.default?.requireRole ??
   requireRoleModule.default ??
   requireRoleModule;
+const requireOrgRole =
+  requireRoleModule.requireOrgRole ??
+  requireRoleModule.default?.requireOrgRole ??
+  requireRoleModule.requireRole;
 const ROLES =
   requireRoleModule.ROLES ??
   requireRoleModule.default?.ROLES ??
@@ -114,7 +118,7 @@ router.get('/', async (req, res) => {
 
 router.get(
   '/:orgId/plan/summary',
-  requireRole(ROLES.OrgAdmin, ROLES.OrgOwner, ROLES.Support, ROLES.SuperAdmin),
+  requireOrgRole([ROLES.OrgAdmin, ROLES.OrgOwner]),
   async (req, res, next) => {
     const existingClient = req.db || null;
     const client = existingClient || (await pool.connect());

--- a/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
+++ b/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
@@ -1,5 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
-import { adminListOrgs, adminListPlans, patchAdminOrg } from "@/api/inboxApi";
+import {
+  adminListOrgs,
+  adminListPlans,
+  patchAdminOrg,
+  patchAdminOrgCredits,
+  putAdminOrgPlan,
+} from "@/api/inboxApi";
 
 function toInputDate(value) {
   if (!value) return "";
@@ -12,25 +18,99 @@ function toInputDate(value) {
   }
 }
 
-const STATUS_OPTIONS = [
+const ORG_STATUS_OPTIONS = [
   { value: "active", label: "Ativa" },
   { value: "inactive", label: "Inativa" },
 ];
 
+const PLAN_STATUS_OPTIONS = [
+  { value: "active", label: "Ativo" },
+  { value: "pending", label: "Pendente" },
+  { value: "suspended", label: "Suspenso" },
+  { value: "canceled", label: "Cancelado" },
+];
+
+function fromInputDate(value) {
+  if (!value) return null;
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toISOString();
+  } catch {
+    return null;
+  }
+}
+
+function fromInputDateTime(value) {
+  if (!value) return null;
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toISOString();
+  } catch {
+    return null;
+  }
+}
+
 function EditOrgModal({ org, onClose, onSaved }) {
-  const [form, setForm] = useState({ plan_id: "", status: "active", trial_ends_at: "" });
+  const [basicForm, setBasicForm] = useState({
+    name: "",
+    slug: "",
+    status: "active",
+    email: "",
+    phone: "",
+    trial_ends_at: "",
+  });
+  const [planForm, setPlanForm] = useState({
+    plan_id: "",
+    status: "active",
+    start_at: "",
+    end_at: "",
+    trial_ends_at: "",
+    meta: "",
+  });
+  const [creditsForm, setCreditsForm] = useState({
+    feature_code: "",
+    delta: "",
+    expires_at: "",
+    source: "manual",
+    meta: "",
+  });
   const [plans, setPlans] = useState([]);
   const [loadingPlans, setLoadingPlans] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
+  const [savingBasic, setSavingBasic] = useState(false);
+  const [savingPlan, setSavingPlan] = useState(false);
+  const [savingCredits, setSavingCredits] = useState(false);
+  const [basicError, setBasicError] = useState("");
+  const [basicSuccess, setBasicSuccess] = useState("");
+  const [planError, setPlanError] = useState("");
+  const [planSuccess, setPlanSuccess] = useState("");
+  const [creditsError, setCreditsError] = useState("");
+  const [creditsSuccess, setCreditsSuccess] = useState("");
 
   useEffect(() => {
     if (!org) return;
-    setForm({
-      plan_id: org.plan_id || "",
+    setBasicForm({
+      name: org.name || "",
+      slug: org.slug || "",
       status: org.status || "active",
+      email: org.email || "",
+      phone: org.phone || "",
       trial_ends_at: toInputDate(org.trial_ends_at),
     });
+    setPlanForm((prev) => ({
+      ...prev,
+      plan_id: org.plan_id || "",
+      status: org.status === "inactive" ? "suspended" : "active",
+      trial_ends_at: toInputDate(org.trial_ends_at),
+    }));
+    setCreditsForm((prev) => ({ ...prev, feature_code: "", delta: "", expires_at: "", meta: "" }));
+    setBasicError("");
+    setBasicSuccess("");
+    setPlanError("");
+    setPlanSuccess("");
+    setCreditsError("");
+    setCreditsSuccess("");
   }, [org]);
 
   useEffect(() => {
@@ -74,26 +154,40 @@ function EditOrgModal({ org, onClose, onSaved }) {
 
   if (!org) return null;
 
-  const handleChange = (field) => (event) => {
-    const value = event?.target?.value ?? "";
-    setForm((prev) => ({ ...prev, [field]: value }));
-  };
-
   const close = () => {
-    if (saving) return;
+    if (savingBasic || savingPlan || savingCredits) return;
     onClose?.();
   };
 
-  const submit = async (event) => {
+  const handleBasicChange = (field) => (event) => {
+    const value = event?.target?.value ?? "";
+    setBasicForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handlePlanChange = (field) => (event) => {
+    const value = event?.target?.value ?? "";
+    setPlanForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleCreditsChange = (field) => (event) => {
+    const value = event?.target?.value ?? "";
+    setCreditsForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const submitBasic = async (event) => {
     event?.preventDefault();
-    if (saving) return;
-    setError("");
-    setSaving(true);
+    if (savingBasic) return;
+    setBasicError("");
+    setBasicSuccess("");
+    setSavingBasic(true);
     try {
       const payload = {
-        plan_id: form.plan_id || null,
-        status: form.status || "active",
-        trial_ends_at: form.trial_ends_at || null,
+        name: basicForm.name?.trim() || org.name || "",
+        slug: basicForm.slug?.trim() || null,
+        status: basicForm.status || "active",
+        email: basicForm.email?.trim() || null,
+        phone: basicForm.phone?.trim() || null,
+        trial_ends_at: fromInputDate(basicForm.trial_ends_at),
       };
       const response = await patchAdminOrg(org.id, payload);
       const data = response?.data;
@@ -104,93 +198,412 @@ function EditOrgModal({ org, onClose, onSaved }) {
         ...(!data?.org && !data?.data ? data || {} : {}),
         ...payload,
       };
-      const planId = merged.plan_id ?? payload.plan_id ?? org.plan_id ?? null;
-      const next = {
-        ...merged,
-        plan_id: planId,
-        plan_name: planMap[planId] || merged.plan_name || org.plan_name || null,
-      };
-      onSaved?.(next);
-      onClose?.();
+      onSaved?.({ ...org, ...merged });
+      setBasicSuccess("Dados atualizados com sucesso.");
     } catch (e) {
       const message = e?.response?.data?.error || e?.message || "Falha ao salvar.";
-      setError(message);
+      setBasicError(message);
     } finally {
-      setSaving(false);
+      setSavingBasic(false);
+    }
+  };
+
+  const submitPlan = async (event) => {
+    event?.preventDefault();
+    if (savingPlan) return;
+    setPlanError("");
+    setPlanSuccess("");
+    if (!planForm.plan_id) {
+      setPlanError("Selecione um plano.");
+      return;
+    }
+    let parsedMeta;
+    if (planForm.meta) {
+      try {
+        parsedMeta = JSON.parse(planForm.meta);
+      } catch {
+        setPlanError("Meta deve ser um JSON válido.");
+        return;
+      }
+    }
+    setSavingPlan(true);
+    try {
+      const payload = {
+        plan_id: planForm.plan_id,
+        status: planForm.status || "active",
+        start_at: fromInputDateTime(planForm.start_at),
+        end_at: fromInputDateTime(planForm.end_at),
+        trial_ends_at: fromInputDate(planForm.trial_ends_at),
+        meta: parsedMeta,
+      };
+      await putAdminOrgPlan(org.id, payload);
+      onSaved?.({
+        ...org,
+        plan_id: payload.plan_id,
+        plan_name: planMap[payload.plan_id] || org.plan_name || null,
+        trial_ends_at: payload.trial_ends_at ?? org.trial_ends_at ?? null,
+      });
+      setPlanSuccess("Plano atualizado com sucesso.");
+    } catch (e) {
+      const message = e?.response?.data?.error || e?.message || "Não foi possível atualizar o plano.";
+      setPlanError(message);
+    } finally {
+      setSavingPlan(false);
+    }
+  };
+
+  const submitCredits = async (event) => {
+    event?.preventDefault();
+    if (savingCredits) return;
+    setCreditsError("");
+    setCreditsSuccess("");
+    const feature = creditsForm.feature_code?.trim();
+    if (!feature) {
+      setCreditsError("Informe o código da feature.");
+      return;
+    }
+    const deltaNumber = Number(creditsForm.delta);
+    if (!Number.isFinite(deltaNumber)) {
+      setCreditsError("Delta deve ser um número.");
+      return;
+    }
+    let meta;
+    if (creditsForm.meta) {
+      try {
+        meta = JSON.parse(creditsForm.meta);
+      } catch {
+        setCreditsError("Meta deve ser JSON válido.");
+        return;
+      }
+    }
+    setSavingCredits(true);
+    try {
+      const payload = {
+        feature_code: feature,
+        delta: Math.trunc(deltaNumber),
+        expires_at: fromInputDateTime(creditsForm.expires_at),
+        source: creditsForm.source?.trim() || undefined,
+        meta,
+      };
+      await patchAdminOrgCredits(org.id, payload);
+      setCreditsSuccess("Créditos registrados.");
+      setCreditsForm((prev) => ({
+        ...prev,
+        feature_code: "",
+        delta: "",
+        expires_at: "",
+        meta: "",
+      }));
+    } catch (e) {
+      const message = e?.response?.data?.error || e?.message || "Não foi possível registrar créditos.";
+      setCreditsError(message);
+    } finally {
+      setSavingCredits(false);
     }
   };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-        <h2 className="text-lg font-semibold">Editar organização</h2>
-        <p className="mt-1 text-sm text-gray-500">{org.name}</p>
-        <form onSubmit={submit} className="mt-4 space-y-4">
-          {error && (
-            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-              {error}
+      <div className="w-full max-w-3xl rounded-lg bg-white p-6 shadow-xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold">Editar organização</h2>
+            <p className="mt-1 text-sm text-gray-500">{org.name}</p>
+          </div>
+          <button
+            type="button"
+            className="text-sm text-gray-500 hover:text-gray-800"
+            onClick={close}
+            disabled={savingBasic || savingPlan || savingCredits}
+          >
+            Fechar
+          </button>
+        </div>
+
+        <div className="mt-4 grid gap-6 md:grid-cols-2">
+          <form
+            onSubmit={submitBasic}
+            className="space-y-3"
+            data-testid="admin-org-basic-form"
+          >
+            <h3 className="font-medium">Dados básicos</h3>
+            {basicError && (
+              <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                {basicError}
+              </div>
+            )}
+            {basicSuccess && (
+              <div className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
+                {basicSuccess}
+              </div>
+            )}
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Nome
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={basicForm.name}
+                onChange={handleBasicChange("name")}
+                disabled={savingBasic}
+                data-testid="admin-org-basic-name"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Slug
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={basicForm.slug}
+                onChange={handleBasicChange("slug")}
+                disabled={savingBasic}
+                data-testid="admin-org-basic-slug"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              E-mail
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={basicForm.email}
+                onChange={handleBasicChange("email")}
+                disabled={savingBasic}
+                data-testid="admin-org-basic-email"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Telefone
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={basicForm.phone}
+                onChange={handleBasicChange("phone")}
+                disabled={savingBasic}
+                data-testid="admin-org-basic-phone"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Status
+              <select
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={basicForm.status}
+                onChange={handleBasicChange("status")}
+                disabled={savingBasic}
+              >
+                {ORG_STATUS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Trial até
+              <input
+                type="date"
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={basicForm.trial_ends_at || ""}
+                onChange={handleBasicChange("trial_ends_at")}
+                disabled={savingBasic}
+              />
+            </label>
+            <div className="flex justify-end pt-2">
+              <button
+                type="submit"
+                className="rounded bg-blue-600 px-4 py-2 text-sm text-white disabled:opacity-60"
+                disabled={savingBasic}
+                data-testid="admin-org-basic-save"
+              >
+                {savingBasic ? "Salvando…" : "Salvar"}
+              </button>
+            </div>
+          </form>
+
+          <form
+            onSubmit={submitPlan}
+            className="space-y-3"
+            data-testid="admin-org-plan-form"
+          >
+            <h3 className="font-medium">Plano</h3>
+            {planError && (
+              <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                {planError}
+              </div>
+            )}
+            {planSuccess && (
+              <div className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
+                {planSuccess}
+              </div>
+            )}
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Plano
+              <select
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={planForm.plan_id}
+                onChange={handlePlanChange("plan_id")}
+                disabled={loadingPlans || savingPlan}
+                data-testid="admin-org-plan-select"
+              >
+                <option value="">—</option>
+                {plans.map((plan) => {
+                  const value = plan.id || plan.slug || plan.id_legacy_text || "";
+                  const label = plan.name || plan.title || plan.label || value;
+                  return (
+                    <option key={value || plan.name} value={value}>
+                      {label}
+                    </option>
+                  );
+                })}
+              </select>
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Status do histórico
+              <select
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={planForm.status}
+                onChange={handlePlanChange("status")}
+                disabled={savingPlan}
+                data-testid="admin-org-plan-status"
+              >
+                {PLAN_STATUS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Trial até
+              <input
+                type="date"
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={planForm.trial_ends_at || ""}
+                onChange={handlePlanChange("trial_ends_at")}
+                disabled={savingPlan}
+                data-testid="admin-org-plan-trial"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Início
+              <input
+                type="datetime-local"
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={planForm.start_at}
+                onChange={handlePlanChange("start_at")}
+                disabled={savingPlan}
+                data-testid="admin-org-plan-start"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Encerramento
+              <input
+                type="datetime-local"
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={planForm.end_at}
+                onChange={handlePlanChange("end_at")}
+                disabled={savingPlan}
+                data-testid="admin-org-plan-end"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Meta (JSON opcional)
+              <textarea
+                className="mt-1 h-24 w-full rounded border px-3 py-2 text-sm"
+                value={planForm.meta}
+                onChange={handlePlanChange("meta")}
+                disabled={savingPlan}
+                data-testid="admin-org-plan-meta"
+              />
+            </label>
+            <div className="flex justify-end pt-2">
+              <button
+                type="submit"
+                className="rounded bg-indigo-600 px-4 py-2 text-sm text-white disabled:opacity-60"
+                disabled={savingPlan}
+                data-testid="admin-org-plan-save"
+              >
+                {savingPlan ? "Registrando…" : "Registrar plano"}
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <form
+          onSubmit={submitCredits}
+          className="mt-6 space-y-3"
+          data-testid="admin-org-credits-form"
+        >
+          <h3 className="font-medium">Créditos</h3>
+          <p className="text-xs text-gray-500">
+            Ajuste manual de créditos para recursos específicos da organização.
+          </p>
+          {creditsError && (
+            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+              {creditsError}
             </div>
           )}
-          <label className="block text-sm">
-            <span className="text-gray-600">Plano</span>
-            <select
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={form.plan_id || ""}
-              onChange={handleChange("plan_id")}
-              disabled={loadingPlans || saving}
-            >
-              <option value="">—</option>
-              {plans.map((plan) => {
-                const value = plan.id || plan.slug || plan.id_legacy_text || "";
-                const label = plan.name || plan.title || plan.label || value;
-                return (
-                  <option key={value || plan.name} value={value}>
-                    {label}
-                  </option>
-                );
-              })}
-            </select>
-          </label>
-          <label className="block text-sm">
-            <span className="text-gray-600">Status</span>
-            <select
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={form.status}
-              onChange={handleChange("status")}
-              disabled={saving}
-            >
-              {STATUS_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="block text-sm">
-            <span className="text-gray-600">Trial até</span>
-            <input
-              type="date"
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={form.trial_ends_at || ""}
-              onChange={handleChange("trial_ends_at")}
-              disabled={saving}
+          {creditsSuccess && (
+            <div className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
+              {creditsSuccess}
+            </div>
+          )}
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Feature
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={creditsForm.feature_code}
+                onChange={handleCreditsChange("feature_code")}
+                disabled={savingCredits}
+                data-testid="admin-org-credits-feature"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Delta
+              <input
+                type="number"
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={creditsForm.delta}
+                onChange={handleCreditsChange("delta")}
+                disabled={savingCredits}
+                data-testid="admin-org-credits-delta"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Expira em
+              <input
+                type="datetime-local"
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={creditsForm.expires_at}
+                onChange={handleCreditsChange("expires_at")}
+                disabled={savingCredits}
+                data-testid="admin-org-credits-expires"
+              />
+            </label>
+            <label className="block text-xs uppercase tracking-wide text-gray-500">
+              Fonte
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={creditsForm.source}
+                onChange={handleCreditsChange("source")}
+                disabled={savingCredits}
+                data-testid="admin-org-credits-source"
+              />
+            </label>
+          </div>
+          <label className="block text-xs uppercase tracking-wide text-gray-500">
+            Meta (JSON opcional)
+            <textarea
+              className="mt-1 h-24 w-full rounded border px-3 py-2 text-sm"
+              value={creditsForm.meta}
+              onChange={handleCreditsChange("meta")}
+              disabled={savingCredits}
+              data-testid="admin-org-credits-meta"
             />
           </label>
-          <div className="flex justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={close}
-              className="rounded border px-4 py-2 text-sm"
-              disabled={saving}
-            >
-              Cancelar
-            </button>
+          <div className="flex justify-end">
             <button
               type="submit"
-              className="rounded bg-blue-600 px-4 py-2 text-sm text-white disabled:opacity-60"
-              disabled={saving}
+              className="rounded bg-emerald-600 px-4 py-2 text-sm text-white disabled:opacity-60"
+              disabled={savingCredits}
+              data-testid="admin-org-credits-save"
             >
-              {saving ? "Salvando…" : "Salvar"}
+              {savingCredits ? "Registrando…" : "Aplicar créditos"}
             </button>
           </div>
         </form>

--- a/frontend/test/AdminOrganizationsPage.test.jsx
+++ b/frontend/test/AdminOrganizationsPage.test.jsx
@@ -1,14 +1,30 @@
 import React from "react";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderApp } from "./utils/renderApp.jsx";
-import inboxApi, { adminListOrgs } from "../src/api/inboxApi";
+import { actTick } from "./utils/actUtils";
+import inboxApi, {
+  adminListOrgs,
+  adminListPlans,
+  patchAdminOrg,
+  patchAdminOrgCredits,
+  putAdminOrgPlan,
+} from "../src/api/inboxApi";
 import AdminOrganizationsPage from "../src/pages/admin/organizations/AdminOrganizationsPage.jsx";
 
 beforeEach(() => {
   inboxApi.__resetRoutes?.();
   adminListOrgs.mockClear?.();
+  adminListPlans.mockClear?.();
+  patchAdminOrg.mockClear?.();
+  putAdminOrgPlan.mockClear?.();
+  patchAdminOrgCredits.mockClear?.();
   localStorage.clear();
   localStorage.setItem("token", "test-token");
+  adminListPlans.mockResolvedValue([
+    { id: "plan-1", name: "Plano Starter" },
+    { id: "plan-2", name: "Plano Pro" },
+  ]);
 });
 
 test("carrega organizações ativas por padrão", async () => {
@@ -25,4 +41,122 @@ test("carrega organizações ativas por padrão", async () => {
   await waitFor(() => expect(adminListOrgs).toHaveBeenCalledWith({ status: "active" }));
   expect(await screen.findByText("Empresa A")).toBeInTheDocument();
   expect(screen.getByText("Empresa B")).toBeInTheDocument();
+});
+
+test("edita dados básicos da organização", async () => {
+  const user = userEvent.setup();
+  adminListOrgs.mockResolvedValueOnce([
+    { id: "org-1", name: "Empresa A", slug: "empresa-a", status: "active" },
+  ]);
+  patchAdminOrg.mockResolvedValueOnce({ data: { org: { name: "Empresa Atualizada" } } });
+
+  renderApp(<AdminOrganizationsPage />, {
+    route: "/admin/organizations",
+    user: { id: "admin", role: "SuperAdmin", roles: ["SuperAdmin"] },
+  });
+
+  await actTick();
+  await screen.findByText("Empresa A");
+  const editButton = await screen.findByText("Editar");
+  await user.click(editButton);
+
+  await actTick();
+  await screen.findByTestId("admin-org-basic-form");
+  const nameInput = screen.getByTestId("admin-org-basic-name");
+  await user.clear(nameInput);
+  await user.type(nameInput, "Nova Empresa");
+
+  const saveButton = screen.getByTestId("admin-org-basic-save");
+  await user.click(saveButton);
+
+  await actTick();
+  await waitFor(() =>
+    expect(patchAdminOrg).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ name: "Nova Empresa" })
+    )
+  );
+  expect(await screen.findByText(/Dados atualizados com sucesso/i)).toBeInTheDocument();
+});
+
+test("registra novo plano manualmente", async () => {
+  const user = userEvent.setup();
+  adminListOrgs.mockResolvedValueOnce([
+    { id: "org-1", name: "Empresa A", slug: "empresa-a", status: "active", plan_id: "plan-1" },
+  ]);
+  putAdminOrgPlan.mockResolvedValueOnce({ data: { ok: true } });
+
+  renderApp(<AdminOrganizationsPage />, {
+    route: "/admin/organizations",
+    user: { id: "admin", role: "SuperAdmin", roles: ["SuperAdmin"] },
+  });
+
+  await actTick();
+  await screen.findByText("Empresa A");
+  const editButton = await screen.findByText("Editar");
+  await user.click(editButton);
+
+  await actTick();
+  await screen.findByTestId("admin-org-plan-form");
+  await user.selectOptions(screen.getByTestId("admin-org-plan-select"), "plan-2");
+  const trialInput = screen.getByTestId("admin-org-plan-trial");
+  fireEvent.change(trialInput, { target: { value: "2024-01-10" } });
+  const metaInput = screen.getByTestId("admin-org-plan-meta");
+  await user.clear(metaInput);
+  await user.type(metaInput, '{"note":"manual"}');
+
+  await user.click(screen.getByTestId("admin-org-plan-save"));
+
+  await actTick();
+  await waitFor(() =>
+    expect(putAdminOrgPlan).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({
+        plan_id: "plan-2",
+        status: "active",
+        trial_ends_at: expect.stringContaining("2024-01-10"),
+        meta: { note: "manual" },
+      })
+    )
+  );
+  expect(await screen.findByText(/Plano atualizado com sucesso/i)).toBeInTheDocument();
+});
+
+test("aplica créditos extras", async () => {
+  const user = userEvent.setup();
+  adminListOrgs.mockResolvedValueOnce([
+    { id: "org-1", name: "Empresa A", slug: "empresa-a", status: "active" },
+  ]);
+  patchAdminOrgCredits.mockResolvedValueOnce({ data: { ok: true } });
+
+  renderApp(<AdminOrganizationsPage />, {
+    route: "/admin/organizations",
+    user: { id: "admin", role: "SuperAdmin", roles: ["SuperAdmin"] },
+  });
+
+  await actTick();
+  await screen.findByText("Empresa A");
+  const editButton = await screen.findByText("Editar");
+  await user.click(editButton);
+
+  await actTick();
+  await screen.findByTestId("admin-org-credits-form");
+  fireEvent.change(screen.getByTestId("admin-org-credits-feature"), {
+    target: { value: "ai_posts" },
+  });
+  fireEvent.change(screen.getByTestId("admin-org-credits-delta"), {
+    target: { value: "5" },
+  });
+  await user.type(screen.getByTestId("admin-org-credits-meta"), '{"reason":"teste"}');
+
+  await user.click(screen.getByTestId("admin-org-credits-save"));
+
+  await actTick();
+  await waitFor(() =>
+    expect(patchAdminOrgCredits).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ feature_code: "ai_posts", delta: 5, meta: { reason: "teste" } })
+    )
+  );
+  expect(await screen.findByText(/Créditos registrados/i)).toBeInTheDocument();
 });

--- a/frontend/test/auth.roles.test.js
+++ b/frontend/test/auth.roles.test.js
@@ -1,0 +1,33 @@
+import {
+  GLOBAL_ROLES,
+  ORG_ROLES,
+  hasGlobalRole,
+  hasOrgRole,
+  normalizeGlobalRoles,
+  normalizeOrgRole,
+} from '@/auth/roles';
+
+describe('auth roles helpers', () => {
+  it('normalizes org roles', () => {
+    expect(normalizeOrgRole('OrgAdmin')).toBe('OrgAdmin');
+    expect(normalizeOrgRole('InvalidRole')).toBe(ORG_ROLES[0]);
+  });
+
+  it('filters global roles', () => {
+    const normalized = normalizeGlobalRoles(['Support', 'Other', 'SuperAdmin']);
+    expect(normalized).toEqual(['Support', 'SuperAdmin']);
+  });
+
+  it('checks org role membership', () => {
+    const user = { role: 'OrgOwner' };
+    expect(hasOrgRole(['OrgAdmin', 'OrgOwner'], user)).toBe(true);
+    expect(hasOrgRole(['OrgAdmin'], user)).toBe(false);
+  });
+
+  it('checks global roles', () => {
+    const user = { roles: ['Support'] };
+    expect(hasGlobalRole(GLOBAL_ROLES[0], user)).toBe(true);
+    expect(hasGlobalRole('SuperAdmin', user)).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Resumo
- adiciona middleware `requireOrgRole` para bloquear acessos a nível de organização e inclui fallback automático para SuperAdmin/Support
- normaliza utilitários de papéis no frontend e cobre comportamentos básicos com testes dedicados

## Checklist da fase 1
- [x] 1/6 – RBAC coeso BE/FE/DB (auth/login/me; middleware; helpers FE; migrações roles)
- [ ] 2/6 – Admin Orgs: endpoints (GET/PATCH/PUT) + telas e formulários
- [ ] 3/6 – Admin Plans: listar/editar features + tela
- [ ] 4/6 – Org Plan Summary: endpoint + tela “Meu Plano”
- [ ] 5/6 – Seeds idempotentes (plans, user_global_roles, credits)
- [ ] 6/6 – Testes BE/FE e mocks atualizados

## Testes executados
- `npm test -- requireRole.middleware.spec.cjs` (backend)
- `npx jest --config jest.config.cjs test/auth.roles.test.js` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d896fa9bd48327ae0821aff7150f9a