### PR TITLE
Fix admin plans payload and harden frontend handling

### DIFF
--- a/backend/routes/admin/plans.js
+++ b/backend/routes/admin/plans.js
@@ -40,21 +40,24 @@ router.use(requireGlobalRole(['SuperAdmin', 'Support']));
 
 router.get('/', async (req, res, next) => {
   try {
-    const q = getQuery(req);
-    const { rows } = await q(
-      `SELECT id, id_legacy_text, name, monthly_price, currency, modules
-         FROM public.plans
-        ORDER BY sort_order NULLS LAST, name ASC`
-    );
-    const payload = rows.map((row) => ({
-      id: row.id,
-      id_legacy_text: row.id_legacy_text ?? null,
-      name: row.name,
-      monthly_price: row.monthly_price,
-      currency: row.currency,
-      modules: row.modules ?? null,
-    }));
-    res.json(payload);
+    const { rows } = await rootQuery(`
+        SELECT
+          id,
+          id_legacy_text,
+          name,
+          monthly_price,
+          currency,
+          modules,
+          is_published,
+          is_active,
+          price_cents,
+          sort_order
+        FROM public.plans
+        ORDER BY
+          COALESCE(sort_order, 9999) ASC,
+          created_at ASC
+      `);
+    res.json({ data: rows });
   } catch (err) {
     next(err);
   }

--- a/frontend/src/api/__mocks__/inboxApi.js
+++ b/frontend/src/api/__mocks__/inboxApi.js
@@ -79,8 +79,30 @@ const state = {
     },
   },
   adminPlans: [
-    { id: "starter", name: "Starter", period: "monthly", price_cents: 0 },
-    { id: "pro", name: "Pro", period: "monthly", price_cents: 9900 },
+    {
+      id: "starter",
+      id_legacy_text: "starter",
+      name: "Starter",
+      monthly_price: 79,
+      currency: "BRL",
+      modules: {},
+      is_published: true,
+      is_active: true,
+      price_cents: 7900,
+      sort_order: 2,
+    },
+    {
+      id: "pro",
+      id_legacy_text: "pro",
+      name: "Pro",
+      monthly_price: 199,
+      currency: "BRL",
+      modules: {},
+      is_published: true,
+      is_active: true,
+      price_cents: 19900,
+      sort_order: 3,
+    },
   ],
   planFeaturesByPlan: {
     starter: [

--- a/frontend/src/api/inboxApi.js
+++ b/frontend/src/api/inboxApi.js
@@ -351,11 +351,20 @@ export async function listAdminPlans(options = {}) {
 }
 
 export async function adminListPlans(options = {}) {
-  const res = await client.get('/admin/plans', withGlobalScope(options));
+  const res = await client.get("/admin/plans", withGlobalScope(options));
   if (res?.status !== 200) throw new Error(`admin/plans ${res?.status}`);
-  const data = res?.data;
-  if (!Array.isArray(data)) throw new Error('admin/plans payload inválido');
-  return data;
+
+  const payload = res?.data;
+  const list = Array.isArray(payload) ? payload : Array.isArray(payload?.data) ? payload.data : null;
+
+  if (!Array.isArray(list)) {
+    const dbg = typeof payload === "object" ? JSON.stringify(payload) : String(payload);
+    const err = new Error("admin/plans payload inválido");
+    err.meta = { received: dbg };
+    throw err;
+  }
+
+  return list;
 }
 
 export async function createPlan(payload, options = {}) {


### PR DESCRIPTION
## Summary
- normalize the `/api/admin/plans` response to always return `{ data: [...] }` with the fields used by the UI
- make the admin plans API helper tolerant to either wrapped or raw arrays and attach debugging metadata on invalid payloads
- tighten the admin plans page and mocks by enforcing SuperAdmin/Support access, clarifying empty states, and mirroring plan fields

## Testing
- npm run test:frontend -- PlansAdminPage.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d9c74132f883279b7c3fc0d528c289