### PR TITLE
Add organization endpoints and stabilize admin plans payload

### DIFF
--- a/backend/routes/admin/plans.js
+++ b/backend/routes/admin/plans.js
@@ -40,23 +40,24 @@ router.use(requireGlobalRole(['SuperAdmin', 'Support']));
 
 router.get('/', async (req, res, next) => {
   try {
-    const { rows } = await rootQuery(`
-        SELECT
-          id,
-          id_legacy_text,
-          name,
-          monthly_price,
-          currency,
-          modules,
-          is_published,
-          is_active,
-          price_cents,
-          sort_order
-        FROM public.plans
-        ORDER BY
-          COALESCE(sort_order, 9999) ASC,
-          created_at ASC
-      `);
+    const { rows } = await rootQuery(
+      `SELECT id,
+              id_legacy_text,
+              name,
+              monthly_price,
+              currency,
+              modules,
+              is_published,
+              is_active,
+              price_cents,
+              billing_period_months,
+              trial_days,
+              sort_order,
+              created_at,
+              updated_at
+         FROM public.plans
+        ORDER BY COALESCE(sort_order, 999999), name ASC`
+    );
     res.json({ data: rows });
   } catch (err) {
     next(err);

--- a/frontend/src/api/inboxApi.js
+++ b/frontend/src/api/inboxApi.js
@@ -355,13 +355,15 @@ export async function adminListPlans(options = {}) {
   if (res?.status !== 200) throw new Error(`admin/plans ${res?.status}`);
 
   const payload = res?.data;
-  const list = Array.isArray(payload) ? payload : Array.isArray(payload?.data) ? payload.data : null;
+  const list = Array.isArray(payload?.data)
+    ? payload.data
+    : Array.isArray(payload)
+    ? payload
+    : null;
 
-  if (!Array.isArray(list)) {
-    const dbg = typeof payload === "object" ? JSON.stringify(payload) : String(payload);
-    const err = new Error("admin/plans payload inválido");
-    err.meta = { received: dbg };
-    throw err;
+  if (!list) {
+    const meta = typeof payload === "object" ? Object.keys(payload || {}) : typeof payload;
+    throw new Error("admin/plans payload inválido - got: " + String(meta));
   }
 
   return list;


### PR DESCRIPTION
## Summary
- add `/api/orgs/current` and streamline `/api/orgs/accessible` to return required organization metadata via the shared pool
- normalize the admin plans listing response to always use a `{ data: [...] }` wrapper and include all plan fields the UI reads
- harden the inbox API helper so it tolerates either wrapped or raw plan lists when decoding responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9cc721e148327816376cae1d085d0