### PR TITLE
Normalize admin plans payload handling

### DIFF
--- a/frontend/src/api/__mocks__/inboxApi.js
+++ b/frontend/src/api/__mocks__/inboxApi.js
@@ -7,6 +7,51 @@ export const apiUrl = "http://mock.local";
 export const setOrgIdHeaderProvider = (typeof jest !== "undefined" ? jest.fn(() => {}) : () => {});
 export const setTokenProvider = (typeof jest !== "undefined" ? jest.fn(() => {}) : () => {});
 
+export const __mockPlans = [
+  {
+    id: "p_free",
+    id_legacy_text: "free",
+    name: "Free",
+    price_cents: 0,
+    monthly_price: 0,
+    currency: "BRL",
+    modules: {},
+    is_active: true,
+    is_published: true,
+    billing_period_months: 1,
+    trial_days: 14,
+    sort_order: 10,
+  },
+  {
+    id: "starter",
+    id_legacy_text: "starter",
+    name: "Starter",
+    price_cents: 7900,
+    monthly_price: 79,
+    currency: "BRL",
+    modules: {},
+    is_active: true,
+    is_published: true,
+    billing_period_months: 1,
+    trial_days: 14,
+    sort_order: 20,
+  },
+  {
+    id: "pro",
+    id_legacy_text: "pro",
+    name: "Pro",
+    price_cents: 19900,
+    monthly_price: 199,
+    currency: "BRL",
+    modules: {},
+    is_active: true,
+    is_published: true,
+    billing_period_months: 1,
+    trial_days: 14,
+    sort_order: 30,
+  },
+];
+
 // ---- Estado em memória (pode ser sobrescrito via __seed) ----
 const state = {
   profilesByOrg: {
@@ -78,33 +123,12 @@ const state = {
       ],
     },
   },
-  adminPlans: [
-    {
-      id: "starter",
-      id_legacy_text: "starter",
-      name: "Starter",
-      monthly_price: 79,
-      currency: "BRL",
-      modules: {},
-      is_published: true,
-      is_active: true,
-      price_cents: 7900,
-      sort_order: 2,
-    },
-    {
-      id: "pro",
-      id_legacy_text: "pro",
-      name: "Pro",
-      monthly_price: 199,
-      currency: "BRL",
-      modules: {},
-      is_published: true,
-      is_active: true,
-      price_cents: 19900,
-      sort_order: 3,
-    },
-  ],
+  adminPlans: __mockPlans.map((plan) => ({ ...plan })),
   planFeaturesByPlan: {
+    p_free: [
+      { code: "posts", label: "Posts", type: "number", value: 10 },
+      { code: "support", label: "Suporte", type: "string", value: "Comunidade" },
+    ],
     starter: [
       { code: "posts", label: "Posts", type: "number", value: 50 },
       { code: "whatsapp_numbers", label: "Números WhatsApp", type: "number", value: 1 },
@@ -726,8 +750,14 @@ export const listAdminPlans =
 
 export const adminListPlans =
   typeof jest !== "undefined"
-    ? jest.fn(async () => state.adminPlans.map((plan) => ({ ...plan })))
-    : async () => state.adminPlans.map((plan) => ({ ...plan }));
+    ? jest.fn(async () => ({
+        plans: state.adminPlans.map((plan) => ({ ...plan })),
+        meta: { feature_defs: [], plan_features: [] },
+      }))
+    : async () => ({
+        plans: state.adminPlans.map((plan) => ({ ...plan })),
+        meta: { feature_defs: [], plan_features: [] },
+      });
 
 export const createPlan =
   typeof jest !== "undefined"

--- a/frontend/src/pages/admin/AdminPlans.jsx
+++ b/frontend/src/pages/admin/AdminPlans.jsx
@@ -38,14 +38,8 @@ export default function AdminPlans() {
   const load = async () => {
     try {
       setLoading(true);
-      const data = await adminListPlans();
-      const list = Array.isArray(data)
-        ? data
-        : Array.isArray(data?.data)
-        ? data.data
-        : Array.isArray(data?.plans)
-        ? data.plans
-        : [];
+      const { plans: planList } = await adminListPlans();
+      const list = Array.isArray(planList) ? planList : [];
       const normalized = list.map((p) => ({
         ...DEFAULT_PLAN(),
         ...p,

--- a/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
+++ b/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
@@ -119,15 +119,9 @@ function EditOrgModal({ org, onClose, onSaved }) {
     setLoadingPlans(true);
     (async () => {
       try {
-        const data = await adminListPlans();
+        const { plans: planList } = await adminListPlans();
         if (!cancelled) {
-          const list = Array.isArray(data)
-            ? data
-            : Array.isArray(data?.data)
-            ? data.data
-            : Array.isArray(data?.plans)
-            ? data.plans
-            : [];
+          const list = Array.isArray(planList) ? planList : [];
           setPlans(list);
         }
       } catch {

--- a/frontend/test/AdminOrganizationsPage.test.jsx
+++ b/frontend/test/AdminOrganizationsPage.test.jsx
@@ -32,10 +32,13 @@ beforeEach(() => {
 });
 
 test("carrega organizações ativas por padrão", async () => {
-  adminListPlans.mockImplementationOnce(() => [
-    { id: "plan-1", name: "Plano Starter" },
-    { id: "plan-2", name: "Plano Pro" },
-  ]);
+  adminListPlans.mockImplementationOnce(() => ({
+    plans: [
+      { id: "plan-1", name: "Plano Starter" },
+      { id: "plan-2", name: "Plano Pro" },
+    ],
+    meta: { feature_defs: [], plan_features: [] },
+  }));
   adminListOrgs.mockResolvedValueOnce([
     { id: "org-1", name: "Empresa A", slug: "empresa-a", status: "active" },
     { id: "org-2", name: "Empresa B", slug: "empresa-b", status: "inactive" },
@@ -55,10 +58,13 @@ test("carrega organizações ativas por padrão", async () => {
 
 test("edita dados básicos da organização", async () => {
   const user = userEvent.setup();
-  adminListPlans.mockImplementationOnce(() => [
-    { id: "plan-1", name: "Plano Starter" },
-    { id: "plan-2", name: "Plano Pro" },
-  ]);
+  adminListPlans.mockImplementationOnce(() => ({
+    plans: [
+      { id: "plan-1", name: "Plano Starter" },
+      { id: "plan-2", name: "Plano Pro" },
+    ],
+    meta: { feature_defs: [], plan_features: [] },
+  }));
   adminListOrgs.mockResolvedValueOnce([
     { id: "org-1", name: "Empresa A", slug: "empresa-a", status: "active" },
   ]);
@@ -99,10 +105,13 @@ test("edita dados básicos da organização", async () => {
 
 test("registra novo plano manualmente", async () => {
   const user = userEvent.setup();
-  adminListPlans.mockResolvedValueOnce([
-    { id: "plan-1", name: "Plano Starter" },
-    { id: "plan-2", name: "Plano Pro" },
-  ]);
+  adminListPlans.mockResolvedValueOnce({
+    plans: [
+      { id: "plan-1", name: "Plano Starter" },
+      { id: "plan-2", name: "Plano Pro" },
+    ],
+    meta: { feature_defs: [], plan_features: [] },
+  });
   adminListOrgs.mockResolvedValueOnce([
     { id: "org-1", name: "Empresa A", slug: "empresa-a", status: "active", plan_id: "plan-1" },
   ]);
@@ -157,10 +166,13 @@ test("registra novo plano manualmente", async () => {
 
 test("aplica créditos extras", async () => {
   const user = userEvent.setup();
-  adminListPlans.mockResolvedValueOnce([
-    { id: "plan-1", name: "Plano Starter" },
-    { id: "plan-2", name: "Plano Pro" },
-  ]);
+  adminListPlans.mockResolvedValueOnce({
+    plans: [
+      { id: "plan-1", name: "Plano Starter" },
+      { id: "plan-2", name: "Plano Pro" },
+    ],
+    meta: { feature_defs: [], plan_features: [] },
+  });
   adminListOrgs.mockResolvedValueOnce([
     { id: "org-1", name: "Empresa A", slug: "empresa-a", status: "active" },
   ]);

--- a/frontend/test/PlansAdminPage.test.jsx
+++ b/frontend/test/PlansAdminPage.test.jsx
@@ -7,10 +7,13 @@ afterEach(() => {
 });
 
 test("carrega e lista planos", async () => {
-  jest.spyOn(api, "adminListPlans").mockResolvedValue([
-    { id: "p1", name: "Starter", currency: "BRL", monthly_price: 79 },
-    { id: "p2", name: "Pro", currency: "BRL", monthly_price: 199 },
-  ]);
+  jest.spyOn(api, "adminListPlans").mockResolvedValue({
+    plans: [
+      { id: "p1", name: "Starter", currency: "BRL", monthly_price: 79 },
+      { id: "p2", name: "Pro", currency: "BRL", monthly_price: 199 },
+    ],
+    meta: { feature_defs: [], plan_features: [] },
+  });
   jest.spyOn(api, "adminGetPlanFeatures").mockResolvedValue([
     { code: "posts", label: "Posts", type: "number", value: 10 },
   ]);
@@ -23,9 +26,12 @@ test("carrega e lista planos", async () => {
 });
 
 test("abre plano, altera feature e salva", async () => {
-  jest.spyOn(api, "adminListPlans").mockResolvedValue([
-    { id: "p1", name: "Starter", currency: "BRL", monthly_price: 79 },
-  ]);
+  jest.spyOn(api, "adminListPlans").mockResolvedValue({
+    plans: [
+      { id: "p1", name: "Starter", currency: "BRL", monthly_price: 79 },
+    ],
+    meta: { feature_defs: [], plan_features: [] },
+  });
   jest.spyOn(api, "adminGetPlanFeatures").mockResolvedValue([
     { code: "posts", label: "Posts", type: "number", value: 10 },
     { code: "whatsapp", label: "WhatsApp", type: "boolean", value: true },


### PR DESCRIPTION
## Summary
- ensure `/api/admin/plans` returns normalized plan data alongside feature definitions and feature values in the meta payload
- update the admin plans API helper and UI to consume the wrapped response, storing meta information for plan features
- align API mocks and related admin page tests with the new response format

## Testing
- npm run test:frontend -- --runTestsByPath frontend/test/PlansAdminPage.test.jsx frontend/test/AdminOrganizationsPage.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d9d0396e308327bdd42947460c6065