### PR TITLE
feat: add AI quota management to admin plans

### DIFF
--- a/backend/migrations/20250930_ai_meters.sql
+++ b/backend/migrations/20250930_ai_meters.sql
@@ -1,0 +1,54 @@
+-- 20250930_ai_meters.sql
+-- Catálogos e uso de IA, além de colunas auxiliares em plan_features.
+
+-- A. catálogos e uso de IA
+CREATE TABLE IF NOT EXISTS public.ai_meters (
+  code        text PRIMARY KEY,
+  name        text NOT NULL,
+  unit        text NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.ai_usage (
+  id          bigserial PRIMARY KEY,
+  org_id      uuid NOT NULL REFERENCES public.organizations(id),
+  meter_code  text NOT NULL REFERENCES public.ai_meters(code),
+  qty         numeric NOT NULL CHECK (qty >= 0),
+  source      text NOT NULL DEFAULT 'system',
+  meta        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ai_usage_org_meter_created_at_idx
+  ON public.ai_usage (org_id, meter_code, created_at);
+CREATE INDEX IF NOT EXISTS ai_usage_meter_created_at_idx
+  ON public.ai_usage (meter_code, created_at);
+
+-- B. colunas extras em plan_features (se ainda não existirem)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='plan_features' AND column_name='ai_meter_code'
+  ) THEN
+    ALTER TABLE public.plan_features
+      ADD COLUMN ai_meter_code text NULL REFERENCES public.ai_meters(code);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='plan_features' AND column_name='ai_monthly_quota'
+  ) THEN
+    ALTER TABLE public.plan_features
+      ADD COLUMN ai_monthly_quota numeric NULL CHECK (ai_monthly_quota >= 0);
+  END IF;
+END$$;
+
+-- C. sementes (idempotente)
+INSERT INTO public.ai_meters (code, name, unit)
+VALUES
+  ('content_tokens', 'Tokens de conteúdo', 'tokens'),
+  ('assist_tokens',  'Tokens do assistente', 'tokens'),
+  ('speech_seconds', 'Segundos de fala', 'seconds')
+ON CONFLICT (code) DO NOTHING;

--- a/frontend/src/pages/admin/plans/PlansPage.jsx
+++ b/frontend/src/pages/admin/plans/PlansPage.jsx
@@ -1,23 +1,42 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  adminGetPlanFeatures,
+  adminCreatePlan,
+  adminDeletePlan,
+  adminDuplicatePlan,
   adminListPlans,
-  adminPutPlanFeatures,
+  adminUpdatePlan,
 } from "@/api/inboxApi";
 import { hasGlobalRole } from "@/auth/roles";
 import { useAuth } from "@/contexts/AuthContext";
 
-function formatCurrency(currency, price) {
-  if (price === null || price === undefined) return "—";
+const AI_METER_OPTIONS = [
+  { value: "", label: "Selecione" },
+  { value: "content_tokens", label: "Tokens de conteúdo" },
+  { value: "assist_tokens", label: "Tokens do assistente" },
+  { value: "speech_seconds", label: "Segundos de fala" },
+];
+
+function formatCurrencyDisplay(currency, cents) {
+  const safeCurrency = currency || "BRL";
+  if (cents === null || cents === undefined) return "";
+  const value = Number(cents) / 100;
   try {
-    return new Intl.NumberFormat("pt-BR", {
+    const locale = safeCurrency === "USD" ? "en-US" : "pt-BR";
+    return new Intl.NumberFormat(locale, {
       style: "currency",
-      currency: currency || "BRL",
+      currency: safeCurrency,
       minimumFractionDigits: 2,
-    }).format(Number(price));
+    }).format(value);
   } catch {
-    return `${currency || "BRL"} ${price}`;
+    return `${safeCurrency} ${value.toFixed(2)}`;
   }
+}
+
+function computePriceState(raw, currency) {
+  const stringValue = raw == null ? "" : String(raw);
+  const digits = stringValue.replace(/[^0-9]/g, "");
+  const cents = digits ? Number(digits) : 0;
+  return { cents, display: formatCurrencyDisplay(currency, cents) };
 }
 
 function normalizeEnumOptions(raw) {
@@ -50,67 +69,139 @@ function extractFeatureValue(raw) {
   return raw;
 }
 
-function normalizeFeatures(list = []) {
-  return list.map((feature) => {
-    const options = Array.isArray(feature.options) ? feature.options : [];
-    let value;
-    if (feature.type === "boolean") {
-      value = Boolean(feature.value);
-    } else if (feature.type === "number") {
-      value = typeof feature.value === "number" && Number.isFinite(feature.value)
-        ? String(feature.value)
-        : "";
-    } else if (feature.type === "enum") {
-      if (typeof feature.value === "string" && options?.includes(feature.value)) {
-        value = feature.value;
-      } else {
-        value = options && options.length ? options[0] : "";
-      }
-    } else {
-      value = typeof feature.value === "string" ? feature.value : "";
-    }
-
-    return {
-      code: feature.code,
-      label: feature.label ?? feature.code,
-      type: feature.type,
-      value,
-      options,
+function buildPlanFeaturesMap(planFeatures = []) {
+  const map = {};
+  for (const entry of Array.isArray(planFeatures) ? planFeatures : []) {
+    if (!entry || !entry.plan_id || !entry.feature_code) continue;
+    if (!map[entry.plan_id]) map[entry.plan_id] = {};
+    map[entry.plan_id][entry.feature_code] = {
+      value: extractFeatureValue(entry.value),
+      ai_meter_code: entry.ai_meter_code ?? null,
+      ai_monthly_quota: entry.ai_monthly_quota ?? null,
+      value_type: entry.value_type ?? null,
     };
-  });
+  }
+  return map;
 }
 
-function buildFeaturesFromMeta(planId, defs = [], planFeatures = []) {
-  if (!planId || !Array.isArray(defs) || defs.length === 0) return [];
-  const valueMap = new Map();
-  for (const item of Array.isArray(planFeatures) ? planFeatures : []) {
-    if (!item || item.plan_id !== planId) continue;
-    valueMap.set(item.feature_code, extractFeatureValue(item.value));
-  }
+function supportsAi(def) {
+  if (!def) return false;
+  if (def.supports_ai) return true;
+  if (def.metadata && typeof def.metadata === "object" && def.metadata.supports_ai) return true;
+  if (typeof def.category === "string" && def.category.toLowerCase().includes("ai")) return true;
+  return false;
+}
 
+function buildFeatureForm(defs = [], planId, featuresByPlan = {}) {
+  if (!planId || !Array.isArray(defs)) return [];
+  const byPlan = featuresByPlan[planId] || {};
   return defs
     .map((def) => {
       if (!def || !def.code) return null;
+      const stored = byPlan[def.code] || {};
+      const type = def.type ?? "string";
+      const options = normalizeEnumOptions(def.enum_options);
+      let value;
+      if (type === "boolean") {
+        value = stored.value === null || stored.value === undefined ? false : Boolean(stored.value);
+      } else if (type === "number") {
+        value = stored.value === null || stored.value === undefined ? "" : String(stored.value);
+      } else if (type === "enum") {
+        const defaultValue = options.length ? options[0] : "";
+        value = stored.value === null || stored.value === undefined ? defaultValue : String(stored.value);
+      } else {
+        value = stored.value === null || stored.value === undefined ? "" : String(stored.value);
+      }
       return {
         code: def.code,
         label: def.label ?? def.code,
-        type: def.type ?? "string",
-        value: valueMap.has(def.code) ? valueMap.get(def.code) : null,
-        options: normalizeEnumOptions(def.enum_options),
+        type,
+        category: def.category ?? "geral",
+        options,
+        sort_order: def.sort_order ?? 0,
+        value,
+        supportsAi: supportsAi(def),
+        ai_meter_code: stored.ai_meter_code ?? "",
+        ai_monthly_quota:
+          stored.ai_monthly_quota === null || stored.ai_monthly_quota === undefined
+            ? ""
+            : String(stored.ai_monthly_quota),
       };
     })
     .filter(Boolean);
 }
 
+function groupFeaturesByCategory(list = []) {
+  const map = new Map();
+  for (const feature of list) {
+    const category = feature.category || "geral";
+    if (!map.has(category)) map.set(category, []);
+    map.get(category).push(feature);
+  }
+  return Array.from(map.entries())
+    .map(([category, items]) => ({
+      category,
+      items: items.sort((a, b) => {
+        const order = (a.sort_order ?? 0) - (b.sort_order ?? 0);
+        if (order !== 0) return order;
+        return a.label.localeCompare(b.label);
+      }),
+    }))
+    .sort((a, b) => a.category.localeCompare(b.category));
+}
+
+function featureToPayload(feature) {
+  const payload = { feature_code: feature.code };
+  if (feature.type === "boolean") {
+    payload.value_bool = Boolean(feature.value);
+  } else if (feature.type === "number") {
+    if (feature.value === null || feature.value === undefined || feature.value === "") {
+      payload.value_number = null;
+    } else {
+      const normalized = Number(String(feature.value).replace(/,/g, "."));
+      payload.value_number = Number.isFinite(normalized) ? normalized : null;
+    }
+  } else if (feature.type === "enum" || feature.type === "string") {
+    payload.value = feature.value ?? "";
+  } else {
+    payload.value = feature.value;
+  }
+
+  if (feature.supportsAi || feature.ai_meter_code || feature.ai_monthly_quota) {
+    payload.ai_meter_code = feature.ai_meter_code ? feature.ai_meter_code : null;
+    if (feature.ai_monthly_quota === null || feature.ai_monthly_quota === undefined || feature.ai_monthly_quota === "") {
+      payload.ai_monthly_quota = null;
+    } else {
+      const quota = Number(String(feature.ai_monthly_quota).replace(/,/g, "."));
+      payload.ai_monthly_quota = Number.isFinite(quota) ? quota : null;
+    }
+  }
+
+  return payload;
+}
+
+function createModalState() {
+  return {
+    name: "",
+    currency: "BRL",
+    price_cents: 0,
+    priceInput: formatCurrencyDisplay("BRL", 0),
+    is_active: true,
+  };
+}
+
+function formatCategoryLabel(category) {
+  const text = category || "geral";
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
 export default function PlansPage() {
   const { user } = useAuth();
-  const canView = useMemo(
-    () => hasGlobalRole(["SuperAdmin", "Support"], user),
-    [user]
-  );
+  const canView = useMemo(() => hasGlobalRole(["SuperAdmin", "Support"], user), [user]);
+
   const [plans, setPlans] = useState([]);
   const [featureDefs, setFeatureDefs] = useState([]);
-  const [planFeatures, setPlanFeatures] = useState([]);
+  const [featuresByPlan, setFeaturesByPlan] = useState({});
   const [plansLoading, setPlansLoading] = useState(true);
   const [plansError, setPlansError] = useState("");
 
@@ -120,389 +211,647 @@ export default function PlansPage() {
     [plans, selectedPlanId]
   );
 
-  const [features, setFeatures] = useState([]);
-  const [featuresLoading, setFeaturesLoading] = useState(false);
-  const [featuresError, setFeaturesError] = useState("");
+  const [form, setForm] = useState({
+    name: "",
+    currency: "BRL",
+    price_cents: 0,
+    priceInput: formatCurrencyDisplay("BRL", 0),
+    is_active: true,
+  });
+  const [featureForm, setFeatureForm] = useState([]);
 
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
   const [saveSuccess, setSaveSuccess] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [hasChanges, setHasChanges] = useState(false);
+
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionError, setActionError] = useState("");
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalForm, setModalForm] = useState(createModalState);
+  const [modalError, setModalError] = useState("");
+  const [modalSaving, setModalSaving] = useState(false);
+
+  const loadPlans = useCallback(async () => {
+    setPlansLoading(true);
+    try {
+      const { plans: planList, feature_defs, plan_features } = await adminListPlans();
+      const safePlans = Array.isArray(planList) ? planList : [];
+      setPlans(safePlans);
+      setFeatureDefs(Array.isArray(feature_defs) ? feature_defs : []);
+      setFeaturesByPlan(buildPlanFeaturesMap(plan_features));
+      setPlansError("");
+      setActionError("");
+      if (safePlans.length) {
+        setSelectedPlanId((current) => {
+          if (current && safePlans.some((plan) => plan.id === current)) return current;
+          return safePlans[0].id;
+        });
+      } else {
+        setSelectedPlanId(null);
+      }
+    } catch (error) {
+      const message =
+        error?.response?.data?.message ||
+        error?.response?.data?.error ||
+        error?.message ||
+        "Não foi possível carregar os planos.";
+      setPlansError(message);
+      setPlans([]);
+      setFeatureDefs([]);
+      setFeaturesByPlan({});
+      setSelectedPlanId(null);
+    } finally {
+      setPlansLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!canView) {
       setPlans([]);
-      setSelectedPlanId(null);
-      setPlansError("");
+      setFeatureDefs([]);
+      setFeaturesByPlan({});
       setPlansLoading(false);
+      setPlansError("");
+      setSelectedPlanId(null);
       return;
     }
-
-    let isMounted = true;
-    setPlansLoading(true);
-    setPlansError("");
-
-    (async () => {
-      try {
-        const { plans: planList, meta } = await adminListPlans();
-        if (!isMounted) return;
-        const safePlans = Array.isArray(planList) ? planList : [];
-        setPlans(safePlans);
-        setFeatureDefs(Array.isArray(meta?.feature_defs) ? meta.feature_defs : []);
-        setPlanFeatures(Array.isArray(meta?.plan_features) ? meta.plan_features : []);
-        if (safePlans.length) {
-          setSelectedPlanId((current) => current || safePlans[0].id);
-        } else {
-          setSelectedPlanId(null);
-        }
-      } catch (err) {
-        if (!isMounted) return;
-        const message =
-          err?.response?.data?.message ||
-          err?.response?.data?.error ||
-          err?.message ||
-          "Não foi possível carregar os planos.";
-        setPlansError(message);
-        setPlans([]);
-        setSelectedPlanId(null);
-      } finally {
-        if (isMounted) setPlansLoading(false);
-      }
-    })();
-    return () => {
-      isMounted = false;
-    };
-  }, [canView]);
+    loadPlans();
+  }, [canView, loadPlans]);
 
   useEffect(() => {
-    if (!selectedPlanId) return;
-    const fallback = buildFeaturesFromMeta(selectedPlanId, featureDefs, planFeatures);
-    if (!fallback.length) return;
-    setFeatures((prev) => {
-      if (prev.length) return prev;
-      return normalizeFeatures(fallback);
+    if (!selectedPlan) {
+      setForm({
+        name: "",
+        currency: "BRL",
+        price_cents: 0,
+        priceInput: formatCurrencyDisplay("BRL", 0),
+        is_active: true,
+      });
+      setFeatureForm([]);
+      setDirty(false);
+      setSaveError("");
+      setSaveSuccess(false);
+      return;
+    }
+    const currency = selectedPlan.currency || "BRL";
+    const priceCents = Number(selectedPlan.price_cents ?? 0);
+    setForm({
+      name: selectedPlan.name || "",
+      currency,
+      price_cents: priceCents,
+      priceInput: formatCurrencyDisplay(currency, priceCents),
+      is_active: Boolean(selectedPlan.is_active),
     });
-    setHasChanges(false);
-  }, [selectedPlanId, featureDefs, planFeatures]);
-
-  useEffect(() => {
-    if (!selectedPlanId) {
-      setFeatures([]);
-      setFeaturesError("");
-      setHasChanges(false);
-      return;
-    }
-
-    let isMounted = true;
-    setFeaturesLoading(true);
-    setFeaturesError("");
+    setFeatureForm(buildFeatureForm(featureDefs, selectedPlan.id, featuresByPlan));
+    setDirty(false);
     setSaveError("");
     setSaveSuccess(false);
+  }, [selectedPlan, featureDefs, featuresByPlan]);
 
-    (async () => {
-      try {
-        const items = await adminGetPlanFeatures(selectedPlanId);
-        if (!isMounted) return;
-        const enhanced = Array.isArray(items)
-          ? items.map((feature) => {
-              const def = Array.isArray(featureDefs)
-                ? featureDefs.find((item) => item?.code === feature.code)
-                : null;
-              const options = feature.options ?? (def ? normalizeEnumOptions(def.enum_options) : undefined);
-              return {
-                ...feature,
-                label: feature.label ?? def?.label ?? feature.code,
-                type: feature.type ?? def?.type ?? feature.type ?? "string",
-                options,
-              };
-            })
-          : [];
-        setFeatures(normalizeFeatures(enhanced));
-        setHasChanges(false);
-      } catch (err) {
-        if (!isMounted) return;
-        const message =
-          err?.response?.data?.message ||
-          err?.response?.data?.error ||
-          err?.message ||
-          "Não foi possível carregar as funcionalidades.";
-        setFeaturesError(message);
-        const fallback = buildFeaturesFromMeta(selectedPlanId, featureDefs, planFeatures);
-        if (fallback.length) {
-          setFeatures(normalizeFeatures(fallback));
-          setHasChanges(false);
-        } else {
-          setFeatures([]);
-        }
-      } finally {
-        if (isMounted) setFeaturesLoading(false);
-      }
-    })();
+  const groupedFeatures = useMemo(() => groupFeaturesByCategory(featureForm), [featureForm]);
 
-    return () => {
-      isMounted = false;
-    };
-  }, [selectedPlanId]);
-
-  const handleSelect = (planId) => {
-    if (planId === selectedPlanId) return;
-    setSelectedPlanId(planId);
-  };
-
-  const handleFeatureChange = (code, updater) => {
-    setFeatures((prev) =>
-      prev.map((feature) =>
-        feature.code === code ? { ...feature, value: updater(feature.value) } : feature
-      )
-    );
-    setHasChanges(true);
+  const markDirty = useCallback(() => {
+    setDirty(true);
     setSaveError("");
     setSaveSuccess(false);
+  }, []);
+
+  const applyFeatureUpdate = useCallback(
+    (code, updater) => {
+      setFeatureForm((prev) => prev.map((item) => (item.code === code ? { ...item, ...updater(item) } : item)));
+      markDirty();
+    },
+    [markDirty]
+  );
+
+  const handleNameChange = (event) => {
+    const value = event.target.value;
+    setForm((prev) => ({ ...prev, name: value }));
+    markDirty();
   };
 
-  const handleToggleBoolean = (code) => (event) => {
-    const { checked } = event.target;
-    handleFeatureChange(code, () => checked);
+  const handleCurrencyChange = (event) => {
+    const currency = event.target.value;
+    setForm((prev) => ({
+      ...prev,
+      currency,
+      priceInput: formatCurrencyDisplay(currency, prev.price_cents),
+    }));
+    markDirty();
   };
 
-  const handleChange = (code) => (event) => {
-    handleFeatureChange(code, () => event.target.value);
+  const handlePriceChange = (event) => {
+    const { cents, display } = computePriceState(event.target.value, form.currency);
+    setForm((prev) => ({ ...prev, price_cents: cents, priceInput: display }));
+    markDirty();
   };
 
+  const handleActiveToggle = (event) => {
+    setForm((prev) => ({ ...prev, is_active: event.target.checked }));
+    markDirty();
+  };
+
+  const handleFeatureBooleanChange = useCallback(
+    (code, checked) => {
+      applyFeatureUpdate(code, () => ({ value: checked }));
+    },
+    [applyFeatureUpdate]
+  );
+
+  const handleFeatureNumberChange = useCallback(
+    (code, raw) => {
+      const sanitized = raw.replace(/[^0-9.,-]/g, "");
+      applyFeatureUpdate(code, () => ({ value: sanitized }));
+    },
+    [applyFeatureUpdate]
+  );
+
+  const handleFeatureTextChange = useCallback(
+    (code, value) => {
+      applyFeatureUpdate(code, () => ({ value }));
+    },
+    [applyFeatureUpdate]
+  );
+
+  const handleFeatureAiMeterChange = useCallback(
+    (code, meter) => {
+      applyFeatureUpdate(code, () => ({ ai_meter_code: meter }));
+    },
+    [applyFeatureUpdate]
+  );
+
+  const handleFeatureAiQuotaChange = useCallback(
+    (code, raw) => {
+      const sanitized = raw.replace(/[^0-9.,]/g, "");
+      applyFeatureUpdate(code, () => ({ ai_monthly_quota: sanitized }));
+    },
+    [applyFeatureUpdate]
+  );
   const handleSave = async () => {
-    if (!selectedPlanId || !features.length) return;
+    if (!selectedPlanId) return;
     setSaving(true);
     setSaveError("");
     setSaveSuccess(false);
-
     try {
-      const payload = [];
-      for (const feature of features) {
-        if (!feature?.code) continue;
-        if (feature.type === "number") {
-          if (feature.value === "") {
-            throw new Error("Preencha todos os valores numéricos.");
-          }
-          const parsed = Number(feature.value);
-          if (Number.isNaN(parsed) || !Number.isFinite(parsed)) {
-            throw new Error("Valor numérico inválido.");
-          }
-          payload.push({
-            code: feature.code,
-            type: "number",
-            value: parsed,
-          });
-        } else if (feature.type === "boolean") {
-          payload.push({ code: feature.code, type: "boolean", value: Boolean(feature.value) });
-        } else if (feature.type === "enum") {
-          if (!feature.value) {
-            throw new Error("Selecione uma opção para todos os campos enum.");
-          }
-          const options = Array.isArray(feature.options) ? feature.options : [];
-          payload.push({
-            code: feature.code,
-            type: "enum",
-            value: feature.value,
-            options,
-          });
-        } else {
-          payload.push({ code: feature.code, type: "string", value: feature.value ?? "" });
-        }
-      }
-
-      await adminPutPlanFeatures(selectedPlanId, payload);
-      setHasChanges(false);
+      const payload = {
+        name: form.name,
+        price_cents: form.price_cents,
+        currency: form.currency,
+        is_active: form.is_active,
+        features: featureForm.map(featureToPayload),
+      };
+      await adminUpdatePlan(selectedPlanId, payload);
+      await loadPlans();
       setSaveSuccess(true);
-    } catch (err) {
+      setDirty(false);
+    } catch (error) {
+      const code = error?.response?.data?.error;
       const message =
-        err?.response?.data?.message ||
-        err?.response?.data?.error ||
-        err?.message ||
-        "Falha ao salvar as funcionalidades.";
+        code === "invalid_ai_meter_code"
+          ? "Medidor de IA inválido."
+          : code === "invalid_ai_quota"
+          ? "Cota de IA inválida."
+          : error?.message || "Falha ao salvar plano.";
       setSaveError(message);
     } finally {
       setSaving(false);
     }
   };
 
+  const handleDuplicate = async () => {
+    if (!selectedPlanId) return;
+    setActionLoading(true);
+    setActionError("");
+    try {
+      const response = await adminDuplicatePlan(selectedPlanId);
+      const newId = response?.data?.data?.plan?.id;
+      await loadPlans();
+      if (newId) setSelectedPlanId(newId);
+    } catch (error) {
+      const message =
+        error?.response?.data?.error ||
+        error?.message ||
+        "Falha ao duplicar plano.";
+      setActionError(message);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!selectedPlanId) return;
+    if (!window.confirm("Deseja realmente excluir este plano?")) return;
+    setActionLoading(true);
+    setActionError("");
+    try {
+      await adminDeletePlan(selectedPlanId);
+      await loadPlans();
+    } catch (error) {
+      const message =
+        error?.response?.status === 409
+          ? "Plano em uso por organizações"
+          : error?.response?.data?.error || error?.message || "Falha ao excluir plano.";
+      setActionError(message);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const openModal = () => {
+    setModalForm(createModalState());
+    setModalError("");
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    if (modalSaving) return;
+    setModalOpen(false);
+    setModalError("");
+  };
+
+  const handleModalNameChange = (event) => {
+    setModalForm((prev) => ({ ...prev, name: event.target.value }));
+  };
+
+  const handleModalCurrencyChange = (event) => {
+    const currency = event.target.value;
+    setModalForm((prev) => ({
+      ...prev,
+      currency,
+      priceInput: formatCurrencyDisplay(currency, prev.price_cents),
+    }));
+  };
+
+  const handleModalPriceChange = (event) => {
+    const { cents, display } = computePriceState(event.target.value, modalForm.currency);
+    setModalForm((prev) => ({ ...prev, price_cents: cents, priceInput: display }));
+  };
+
+  const handleModalActiveToggle = (event) => {
+    setModalForm((prev) => ({ ...prev, is_active: event.target.checked }));
+  };
+
+  const handleCreatePlanAction = async () => {
+    setModalError("");
+    const name = modalForm.name.trim();
+    if (!name) {
+      setModalError("Informe o nome do plano.");
+      return;
+    }
+    setModalSaving(true);
+    try {
+      const response = await adminCreatePlan({
+        name,
+        currency: modalForm.currency,
+        price_cents: modalForm.price_cents,
+        is_active: modalForm.is_active,
+      });
+      const newId = response?.data?.data?.plan?.id;
+      setModalOpen(false);
+      setModalForm(createModalState());
+      await loadPlans();
+      if (newId) setSelectedPlanId(newId);
+    } catch (error) {
+      const message = error?.response?.data?.error || error?.message || "Falha ao criar plano.";
+      setModalError(message);
+    } finally {
+      setModalSaving(false);
+    }
+  };
+
   if (!canView) {
     return (
-      <div className="p-6 text-sm text-gray-600">
-        Você não tem permissão para visualizar esta página.
+      <div style={{ padding: "24px" }}>
+        <h1>Planos</h1>
+        <p>Você não possui permissão para visualizar os planos.</p>
       </div>
     );
   }
 
-  if (plansLoading) {
-    return <div className="p-6 text-sm text-gray-600">Carregando planos…</div>;
-  }
-
   return (
-    <div className="p-6 space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Planos</h1>
-        {plansError && (
-          <p className="mt-2 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-            {plansError}
-          </p>
-        )}
-      </div>
-
-      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
-        <div className="space-y-3">
-          <div className="rounded-lg border bg-white shadow-sm">
-            <div className="border-b px-4 py-3 text-sm font-medium text-gray-600">Planos</div>
-            <ul className="divide-y">
-              {plans.map((plan) => (
-                <li
-                  key={plan.id}
-                  data-testid="plan-item"
-                  data-plan-id={plan.id}
-                  className={`cursor-pointer px-4 py-3 text-sm transition hover:bg-gray-50 ${
-                    plan.id === selectedPlanId ? "bg-indigo-50" : ""
-                  }`}
-                  onClick={() => handleSelect(plan.id)}
-                >
-                  <div className="font-medium text-gray-800">{plan.name}</div>
-                  <div className="text-xs text-gray-500">
-                    {formatCurrency(plan.currency, plan.monthly_price)}
-                  </div>
-                </li>
-              ))}
-              {!plans.length && !plansError && (
-                <li className="px-4 py-3 text-sm text-gray-500">Nenhum plano disponível.</li>
-              )}
-            </ul>
+    <div style={{ padding: "24px", maxWidth: "1200px" }}>
+      <h1 style={{ marginBottom: "16px" }}>Planos</h1>
+      {plansError && (
+        <div style={{ marginBottom: "16px", color: "#b91c1c" }}>{plansError}</div>
+      )}
+      <div style={{ display: "flex", gap: "24px", alignItems: "flex-start" }}>
+        <aside style={{ width: "260px" }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px", marginBottom: "16px" }}>
+            <button type="button" onClick={openModal} disabled={plansLoading || actionLoading}>
+              Novo
+            </button>
+            <button
+              type="button"
+              onClick={handleDuplicate}
+              disabled={!selectedPlanId || actionLoading || plansLoading}
+            >
+              Duplicar
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={!selectedPlanId || actionLoading || plansLoading}
+            >
+              Excluir
+            </button>
+            {actionError && (
+              <span style={{ color: "#b91c1c", fontSize: "0.875rem" }}>{actionError}</span>
+            )}
           </div>
-        </div>
-
-        <div className="space-y-4">
-          {!selectedPlan && !plansError && (
-            <div className="rounded-lg border border-dashed px-4 py-6 text-center text-sm text-gray-500">
-              Selecione um plano para visualizar as funcionalidades.
-            </div>
+          {plansLoading ? (
+            <p>Carregando...</p>
+          ) : plans.length === 0 ? (
+            <p>Nenhum plano cadastrado.</p>
+          ) : (
+            <ul
+              style={{
+                listStyle: "none",
+                padding: 0,
+                margin: 0,
+                display: "flex",
+                flexDirection: "column",
+                gap: "8px",
+              }}
+            >
+              {plans.map((plan) => {
+                const priceLabel = formatCurrencyDisplay(
+                  plan.currency || "BRL",
+                  Number(plan.price_cents ?? 0)
+                );
+                const isSelected = plan.id === selectedPlanId;
+                return (
+                  <li key={plan.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedPlanId(plan.id)}
+                      style={{
+                        width: "100%",
+                        textAlign: "left",
+                        padding: "12px",
+                        borderRadius: "8px",
+                        border: isSelected ? "2px solid #2563eb" : "1px solid #d1d5db",
+                        background: isSelected ? "#eff6ff" : "#ffffff",
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "4px",
+                      }}
+                    >
+                      <span style={{ fontWeight: 600 }}>{plan.name}</span>
+                      <span style={{ fontSize: "0.875rem", color: "#4b5563" }}>{priceLabel}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
           )}
+        </aside>
 
-          {selectedPlan && (
-            <div className="rounded-lg border bg-white p-6 shadow-sm">
-              <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <h2 className="text-lg font-semibold text-gray-900">{selectedPlan.name}</h2>
-                  <p className="text-sm text-gray-500">
-                    Valor mensal: {formatCurrency(selectedPlan.currency, selectedPlan.monthly_price)}
-                  </p>
+        <section style={{ flex: 1 }}>
+          {plansLoading ? (
+            <p>Carregando dados do plano...</p>
+          ) : !selectedPlan ? (
+            <p>Selecione um plano para editar.</p>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+              <div style={{ border: "1px solid #e5e7eb", borderRadius: "12px", padding: "16px" }}>
+                <h2 style={{ marginTop: 0 }}>Básico</h2>
+                <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+                  <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                    <span>Nome</span>
+                    <input type="text" value={form.name} onChange={handleNameChange} />
+                  </label>
+                  <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                    <span>Preço</span>
+                    <input type="text" value={form.priceInput} onChange={handlePriceChange} />
+                  </label>
+                  <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                    <span>Moeda</span>
+                    <select value={form.currency} onChange={handleCurrencyChange}>
+                      <option value="BRL">BRL</option>
+                      <option value="USD">USD</option>
+                    </select>
+                  </label>
+                  <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                    <input type="checkbox" checked={form.is_active} onChange={handleActiveToggle} />
+                    <span>Plano ativo</span>
+                  </label>
                 </div>
+              </div>
+
+              <div style={{ border: "1px solid #e5e7eb", borderRadius: "12px", padding: "16px" }}>
+                <h2 style={{ marginTop: 0 }}>Features</h2>
+                {groupedFeatures.length === 0 ? (
+                  <p>Nenhuma feature configurada.</p>
+                ) : (
+                  <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+                    {groupedFeatures.map((group) => (
+                      <details
+                        key={group.category}
+                        open
+                        style={{ border: "1px solid #f3f4f6", borderRadius: "8px", padding: "8px 12px" }}
+                      >
+                        <summary style={{ cursor: "pointer", fontWeight: 600, marginBottom: "8px" }}>
+                          {formatCategoryLabel(group.category)}
+                        </summary>
+                        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+                          {group.items.map((feature) => {
+                            const showAi =
+                              feature.supportsAi ||
+                              Boolean(feature.ai_meter_code) ||
+                              (feature.ai_monthly_quota !== null && feature.ai_monthly_quota !== "");
+                            let control = null;
+                            if (feature.type === "boolean") {
+                              control = (
+                                <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                                  <input
+                                    type="checkbox"
+                                    checked={Boolean(feature.value)}
+                                    onChange={(event) =>
+                                      handleFeatureBooleanChange(feature.code, event.target.checked)
+                                    }
+                                  />
+                                  <span>{feature.label}</span>
+                                </label>
+                              );
+                            } else if (feature.type === "number") {
+                              control = (
+                                <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                  <span>{feature.label}</span>
+                                  <input
+                                    type="text"
+                                    value={feature.value}
+                                    onChange={(event) =>
+                                      handleFeatureNumberChange(feature.code, event.target.value)
+                                    }
+                                    placeholder="Ex.: 10"
+                                  />
+                                </label>
+                              );
+                            } else if (feature.type === "enum") {
+                              control = (
+                                <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                  <span>{feature.label}</span>
+                                  <select
+                                    value={feature.value}
+                                    onChange={(event) =>
+                                      handleFeatureTextChange(feature.code, event.target.value)
+                                    }
+                                  >
+                                    {feature.options.map((option) => (
+                                      <option key={option} value={option}>
+                                        {option}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </label>
+                              );
+                            } else {
+                              control = (
+                                <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                  <span>{feature.label}</span>
+                                  <input
+                                    type="text"
+                                    value={feature.value}
+                                    onChange={(event) =>
+                                      handleFeatureTextChange(feature.code, event.target.value)
+                                    }
+                                  />
+                                </label>
+                              );
+                            }
+
+                            return (
+                              <div key={feature.code} style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+                                {control}
+                                {showAi && (
+                                  <div
+                                    style={{
+                                      display: "grid",
+                                      gridTemplateColumns: "1fr 1fr",
+                                      gap: "12px",
+                                    }}
+                                  >
+                                    <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                      <span>Medidor de IA</span>
+                                      <select
+                                        value={feature.ai_meter_code}
+                                        onChange={(event) =>
+                                          handleFeatureAiMeterChange(feature.code, event.target.value)
+                                        }
+                                      >
+                                        {AI_METER_OPTIONS.map((option) => (
+                                          <option key={option.value} value={option.value}>
+                                            {option.label}
+                                          </option>
+                                        ))}
+                                      </select>
+                                    </label>
+                                    <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                      <span>Cota mensal</span>
+                                      <input
+                                        type="text"
+                                        value={feature.ai_monthly_quota}
+                                        onChange={(event) =>
+                                          handleFeatureAiQuotaChange(feature.code, event.target.value)
+                                        }
+                                        placeholder="Ex.: 50000"
+                                      />
+                                    </label>
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </details>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
                 <button
                   type="button"
-                  data-testid="btn-save-features"
                   onClick={handleSave}
-                  disabled={saving || !hasChanges || featuresLoading || !!featuresError}
-                  className={`inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium transition ${
-                    saving || !hasChanges || featuresLoading || !!featuresError
-                      ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
-                      : "border-indigo-500 bg-indigo-500 text-white hover:bg-indigo-600"
-                  }`}
+                  disabled={!dirty || saving || plansLoading}
                 >
-                  {saving ? "Salvando…" : "Salvar"}
+                  {saving ? "Salvando..." : "Salvar"}
                 </button>
-              </header>
-
-              {featuresLoading && (
-                <p className="mt-4 text-sm text-gray-500">Carregando funcionalidades…</p>
-              )}
-
-              {featuresError && (
-                <p className="mt-4 rounded border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
-                  {featuresError}
-                </p>
-              )}
-
-              {!featuresLoading && !featuresError && (
-                <div className="mt-4 space-y-4">
-                  {features.length === 0 && (
-                    <p className="text-sm text-gray-500">Nenhuma funcionalidade configurada.</p>
-                  )}
-
-                  {features.map((feature) => (
-                    <div
-                      key={feature.code}
-                      className="rounded border border-gray-200 px-4 py-3"
-                    >
-                      <div className="text-sm font-medium text-gray-800">
-                        {feature.label}
-                        <span className="ml-2 text-xs text-gray-400">({feature.code})</span>
-                      </div>
-                      <div className="mt-2 text-sm text-gray-600">Tipo: {feature.type}</div>
-
-                      <div className="mt-3">
-                        {feature.type === "number" && (
-                          <input
-                            type="number"
-                            className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
-                            value={feature.value}
-                            onChange={handleChange(feature.code)}
-                            data-testid={`feature-input-${feature.code}`}
-                          />
-                        )}
-
-                        {feature.type === "boolean" && (
-                          <label className="inline-flex items-center gap-2 text-sm text-gray-700">
-                            <input
-                              type="checkbox"
-                              checked={Boolean(feature.value)}
-                              onChange={handleToggleBoolean(feature.code)}
-                              className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                              data-testid={`feature-input-${feature.code}`}
-                            />
-                            <span>Ativo</span>
-                          </label>
-                        )}
-
-                        {feature.type === "string" && (
-                          <input
-                            type="text"
-                            className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
-                            value={feature.value}
-                            onChange={handleChange(feature.code)}
-                            data-testid={`feature-input-${feature.code}`}
-                          />
-                        )}
-
-                        {feature.type === "enum" && (
-                          <select
-                            className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
-                            value={feature.value}
-                            onChange={handleChange(feature.code)}
-                            data-testid={`feature-input-${feature.code}`}
-                          >
-                            {(feature.options || []).map((option) => (
-                              <option key={option} value={option}>
-                                {option}
-                              </option>
-                            ))}
-                          </select>
-                        )}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {saveError && (
-                <p className="mt-4 rounded border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
-                  {saveError}
-                </p>
-              )}
-
-              {saveSuccess && (
-                <p className="mt-4 rounded border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm text-emerald-700">
-                  Alterações salvas com sucesso.
-                </p>
-              )}
+                {saveSuccess && <span style={{ color: "#059669" }}>Alterações salvas</span>}
+                {saveError && <span style={{ color: "#b91c1c" }}>{saveError}</span>}
+              </div>
             </div>
           )}
-        </div>
+        </section>
       </div>
+
+      {modalOpen && (
+        <div
+          role="presentation"
+          onClick={closeModal}
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(15, 23, 42, 0.45)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "24px",
+            zIndex: 50,
+          }}
+        >
+          <div
+            role="dialog"
+            onClick={(event) => event.stopPropagation()}
+            style={{
+              width: "min(420px, 100%)",
+              background: "#ffffff",
+              borderRadius: "12px",
+              padding: "24px",
+              boxShadow: "0 20px 45px rgba(15, 23, 42, 0.25)",
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+            }}
+          >
+            <h2 style={{ margin: 0 }}>Novo plano</h2>
+            <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+              <span>Nome</span>
+              <input type="text" value={modalForm.name} onChange={handleModalNameChange} />
+            </label>
+            <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+              <span>Preço</span>
+              <input type="text" value={modalForm.priceInput} onChange={handleModalPriceChange} />
+            </label>
+            <label style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+              <span>Moeda</span>
+              <select value={modalForm.currency} onChange={handleModalCurrencyChange}>
+                <option value="BRL">BRL</option>
+                <option value="USD">USD</option>
+              </select>
+            </label>
+            <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <input
+                type="checkbox"
+                checked={modalForm.is_active}
+                onChange={handleModalActiveToggle}
+              />
+              <span>Plano ativo</span>
+            </label>
+            {modalError && <span style={{ color: "#b91c1c" }}>{modalError}</span>}
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: "12px" }}>
+              <button type="button" onClick={closeModal} disabled={modalSaving}>
+                Cancelar
+              </button>
+              <button type="button" onClick={handleCreatePlanAction} disabled={modalSaving}>
+                {modalSaving ? "Criando..." : "Criar"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/test/PlansAdminPage.test.jsx
+++ b/frontend/test/PlansAdminPage.test.jsx
@@ -1,56 +1,193 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { act } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { within } from "@testing-library/dom";
 import PlansPage from "@/pages/admin/plans/PlansPage";
 import * as api from "@/api/inboxApi";
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const baseResponse = {
+  plans: [
+    { id: "plan-basic", name: "Starter", price_cents: 9900, currency: "BRL", is_active: true },
+    { id: "plan-pro", name: "Pro", price_cents: 19900, currency: "BRL", is_active: true },
+  ],
+  feature_defs: [
+    { code: "whatsapp_numbers", label: "WhatsApp", type: "number", category: "canais", sort_order: 10 },
+    { code: "ai_generation", label: "Geração IA", type: "boolean", category: "ia", sort_order: 20 },
+  ],
+  plan_features: [
+    {
+      plan_id: "plan-basic",
+      feature_code: "whatsapp_numbers",
+      value: { value: 1 },
+      ai_meter_code: null,
+      ai_monthly_quota: null,
+    },
+    {
+      plan_id: "plan-basic",
+      feature_code: "ai_generation",
+      value: { value: true },
+      ai_meter_code: "content_tokens",
+      ai_monthly_quota: 5000,
+    },
+  ],
+};
+
+beforeEach(() => {
+  jest.spyOn(api, "adminListPlans").mockResolvedValue(clone(baseResponse));
+  jest.spyOn(api, "adminUpdatePlan").mockResolvedValue({ data: { ok: true } });
+  jest.spyOn(api, "adminCreatePlan").mockResolvedValue({ data: { plan: { id: "plan-new" } } });
+  jest.spyOn(api, "adminDuplicatePlan").mockResolvedValue({ data: { plan: { id: "plan-copy" } } });
+  jest.spyOn(api, "adminDeletePlan").mockResolvedValue({ data: { deleted: true } });
+});
 
 afterEach(() => {
   jest.restoreAllMocks();
 });
 
 test("carrega e lista planos", async () => {
-  jest.spyOn(api, "adminListPlans").mockResolvedValue({
-    plans: [
-      { id: "p1", name: "Starter", currency: "BRL", monthly_price: 79 },
-      { id: "p2", name: "Pro", currency: "BRL", monthly_price: 199 },
-    ],
-    meta: { feature_defs: [], plan_features: [] },
+  await act(async () => {
+    render(<PlansPage />);
   });
-  jest.spyOn(api, "adminGetPlanFeatures").mockResolvedValue([
-    { code: "posts", label: "Posts", type: "number", value: 10 },
-  ]);
 
-  render(<PlansPage />);
-
-  const items = await screen.findAllByTestId("plan-item");
-  expect(items).toHaveLength(2);
-  expect(items[0]).toHaveTextContent("Starter");
+  const starterLabel = await screen.findByText("Starter");
+  expect(starterLabel).toBeInTheDocument();
+  expect(screen.getByText("Pro")).toBeInTheDocument();
+  expect(screen.getByText(/R\$\s*199,00/)).toBeInTheDocument();
 });
 
-test("abre plano, altera feature e salva", async () => {
-  jest.spyOn(api, "adminListPlans").mockResolvedValue({
-    plans: [
-      { id: "p1", name: "Starter", currency: "BRL", monthly_price: 79 },
-    ],
-    meta: { feature_defs: [], plan_features: [] },
+test("edita feature com campos de IA e salva", async () => {
+  const response = clone(baseResponse);
+  response.feature_defs = [
+    { code: "ai_generation", label: "Geração IA", type: "boolean", category: "ia", sort_order: 10 },
+    { code: "assistants", label: "Assistentes", type: "number", category: "ia", sort_order: 20 },
+  ];
+  response.plan_features = [
+    {
+      plan_id: "plan-basic",
+      feature_code: "ai_generation",
+      value: { value: true },
+      ai_meter_code: "content_tokens",
+      ai_monthly_quota: 1000,
+    },
+    {
+      plan_id: "plan-basic",
+      feature_code: "assistants",
+      value: { value: 5 },
+      ai_meter_code: null,
+      ai_monthly_quota: null,
+    },
+  ];
+  api.adminListPlans.mockResolvedValue(response);
+
+  await act(async () => {
+    render(<PlansPage />);
   });
-  jest.spyOn(api, "adminGetPlanFeatures").mockResolvedValue([
-    { code: "posts", label: "Posts", type: "number", value: 10 },
-    { code: "whatsapp", label: "WhatsApp", type: "boolean", value: true },
-  ]);
-  const putSpy = jest.spyOn(api, "adminPutPlanFeatures").mockResolvedValue({ ok: true });
+  const starterButton = (await screen.findByText("Starter")).closest("button");
+  if (starterButton) fireEvent.click(starterButton);
 
-  render(<PlansPage />);
+  const iaCheckbox = screen.getByLabelText(/Geração IA/i, { selector: "input" });
+  fireEvent.click(iaCheckbox); // desmarca
 
-  await waitFor(() => expect(api.adminGetPlanFeatures).toHaveBeenCalled());
+  const meterSelect = screen.getByLabelText(/Medidor de IA/i);
+  fireEvent.change(meterSelect, { target: { value: "assist_tokens" } });
 
-  const postsInput = await screen.findByTestId("feature-input-posts");
-  fireEvent.change(postsInput, { target: { value: "25" } });
+  const quotaInput = screen.getByPlaceholderText("Ex.: 50000");
+  fireEvent.change(quotaInput, { target: { value: "2000" } });
 
-  const saveButton = screen.getByTestId("btn-save-features");
-  await waitFor(() => expect(saveButton).not.toBeDisabled());
-  fireEvent.click(saveButton);
-  await waitFor(() => expect(putSpy).toHaveBeenCalledTimes(1));
-  expect(putSpy.mock.calls[0][1]).toEqual([
-    { code: "posts", type: "number", value: 25 },
-    { code: "whatsapp", type: "boolean", value: true },
-  ]);
+  const assistantsInput = screen.getByPlaceholderText("Ex.: 10");
+  fireEvent.change(assistantsInput, { target: { value: "12" } });
+
+  const saveButton = screen.getByRole("button", { name: /salvar/i });
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  await act(async () => {
+    fireEvent.click(saveButton);
+  });
+
+  await waitFor(() => expect(api.adminUpdatePlan).toHaveBeenCalled());
+  await waitFor(() => expect(api.adminListPlans).toHaveBeenCalledTimes(2));
+  const payload = api.adminUpdatePlan.mock.calls[0][1];
+  expect(payload.features).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        feature_code: "ai_generation",
+        value_bool: false,
+        ai_meter_code: "assist_tokens",
+        ai_monthly_quota: 2000,
+      }),
+      expect.objectContaining({
+        feature_code: "assistants",
+        value_number: 12,
+      }),
+    ])
+  );
+});
+
+test("cria novo plano pelo modal", async () => {
+  await act(async () => {
+    render(<PlansPage />);
+  });
+  const starterButton = (await screen.findByText("Starter")).closest("button");
+  if (starterButton) fireEvent.click(starterButton);
+
+  const newButton = screen.getByRole("button", { name: /novo/i });
+  fireEvent.click(newButton);
+
+  const modal = await screen.findByRole("dialog");
+  const nameInput = within(modal).getByLabelText(/Nome/i);
+  const priceInput = within(modal).getByLabelText(/Preço/i);
+  const currencySelect = within(modal).getByLabelText(/Moeda/i);
+
+  fireEvent.change(nameInput, { target: { value: "Plano IA" } });
+  fireEvent.change(priceInput, { target: { value: "12900" } });
+  fireEvent.change(currencySelect, { target: { value: "USD" } });
+
+  const createButton = within(modal).getByRole("button", { name: /criar/i });
+  await act(async () => {
+    fireEvent.click(createButton);
+  });
+
+  await waitFor(() => expect(api.adminCreatePlan).toHaveBeenCalled());
+  expect(api.adminCreatePlan).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: "Plano IA",
+      price_cents: 12900,
+      currency: "USD",
+    })
+  );
+  await waitFor(() => expect(api.adminListPlans).toHaveBeenCalledTimes(2));
+});
+
+test("duplica plano selecionado", async () => {
+  await act(async () => {
+    render(<PlansPage />);
+  });
+  const starterButton = (await screen.findByText("Starter")).closest("button");
+  if (starterButton) fireEvent.click(starterButton);
+
+  const duplicateButton = screen.getByRole("button", { name: /duplicar/i });
+  await act(async () => {
+    fireEvent.click(duplicateButton);
+  });
+
+  await waitFor(() => expect(api.adminDuplicatePlan).toHaveBeenCalledWith("plan-basic"));
+  await waitFor(() => expect(api.adminListPlans).toHaveBeenCalledTimes(2));
+});
+
+test("exclui plano quando confirmado", async () => {
+  const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+  await act(async () => {
+    render(<PlansPage />);
+  });
+  const starterButton = (await screen.findByText("Starter")).closest("button");
+  if (starterButton) fireEvent.click(starterButton);
+
+  const deleteButton = screen.getByRole("button", { name: /excluir/i });
+  await act(async () => {
+    fireEvent.click(deleteButton);
+  });
+
+  await waitFor(() => expect(api.adminDeletePlan).toHaveBeenCalledWith("plan-basic"));
+  await waitFor(() => expect(api.adminListPlans).toHaveBeenCalledTimes(2));
+  confirmSpy.mockRestore();
 });


### PR DESCRIPTION
## Summary
- add migration for AI metering tables, seed default meters, and extend plan feature schema
- extend admin plan routes for CRUD, price/currency updates, and AI quota validation
- redesign plans admin UI, API client, mocks, and tests to handle compact layout and AI fields

## Testing
- ⚠️ `npx jest -c jest.config.cjs test/PlansAdminPage.test.jsx` *(fails: environment missing dev dependencies such as supertest, pg, mime-types, pino)*

## Postman / Insomnia
1. **GET** `http://localhost:4000/api/admin/plans`
   - Expect `{ data: { plans: [...], feature_defs: [...], plan_features: [...] } }` with price, currency, and AI fields.
2. **POST** `http://localhost:4000/api/admin/plans`
   - Body: `{ "name": "Plano IA", "price_cents": 9900, "currency": "BRL", "is_active": true }`
   - Optionally include `features[]` entries with `ai_meter_code` and `ai_monthly_quota`.
3. **PATCH** `http://localhost:4000/api/admin/plans/:id`
   - Body example updates name, price, currency, `is_active`, and features with AI quotas.
4. **POST** `http://localhost:4000/api/admin/plans/:id/duplicate`
   - Confirms new plan is returned with copied features.
5. **DELETE** `http://localhost:4000/api/admin/plans/:id`
   - Returns 200 with `{ data: { deleted: true } }` or 409 if plan is in use.


------
https://chatgpt.com/codex/tasks/task_e_68d9ee21500083279d536e598a3b3a5f