### PR TITLE
Fix admin org listing and plan credits summary

### DIFF
--- a/frontend/src/api/__mocks__/inboxApi.js
+++ b/frontend/src/api/__mocks__/inboxApi.js
@@ -980,6 +980,16 @@ export const adminGetPlanCredits =
         return { plan_id: planId, summary };
       };
 
+export async function adminGetPlanCreditsSummary(planId) {
+  return {
+    plan_id: planId,
+    credits: [
+      { meter: 'ai_tokens', limit: 100000, period: 'month' },
+      { meter: 'ai_messages', limit: 2000, period: 'month' },
+    ],
+  };
+}
+
 export const adminPutPlanFeatures =
   typeof jest !== "undefined"
     ? jest.fn(async (planId, features = []) => {
@@ -1021,6 +1031,7 @@ inboxApi.createPlan = createPlan;
 inboxApi.updatePlan = updatePlan;
 inboxApi.adminGetPlanFeatures = adminGetPlanFeatures;
 inboxApi.adminGetPlanCredits = adminGetPlanCredits;
+inboxApi.adminGetPlanCreditsSummary = adminGetPlanCreditsSummary;
 inboxApi.adminPutPlanFeatures = adminPutPlanFeatures;
 
 export const client = inboxApi;


### PR DESCRIPTION
## Summary
- normalize the admin organizations listing to honor status query filters, fallback to legacy tables, and log failures with context
- harden the global RBAC guard so unexpected errors are logged and translated into HTTP 500 responses
- expose the admin plan credits summary endpoint and hook up the frontend to render the new credits card using the dedicated helper and mocks

## Testing
- npm run test:backend *(fails: missing optional dependencies such as supertest/pg in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68dabc87a5448327a8058c6a2f320263