### PR TITLE
Fix admin org status filter and plan credits card

### DIFF
--- a/frontend/src/api/__mocks__/inboxApi.js
+++ b/frontend/src/api/__mocks__/inboxApi.js
@@ -956,38 +956,29 @@ export const adminGetPlanFeatures =
 export const adminGetPlanCredits =
   typeof jest !== "undefined"
     ? jest.fn(async (planId) => {
+        if (!planId) return [];
         const features = state.planFeaturesByPlan[planId] || [];
-        const summary = features
+        return features
           .filter((feature) => (feature.type || "").toLowerCase() === "number")
           .map((feature) => ({
-            code: feature.code,
-            label: feature.label ?? feature.code,
-            unit: "count",
+            meter: feature.code,
             limit: Number.isFinite(Number(feature.value)) ? Number(feature.value) : 0,
           }));
-        return { plan_id: planId, summary };
       })
     : async (planId) => {
+        if (!planId) return [];
         const features = state.planFeaturesByPlan[planId] || [];
-        const summary = features
+        return features
           .filter((feature) => (feature.type || "").toLowerCase() === "number")
           .map((feature) => ({
-            code: feature.code,
-            label: feature.label ?? feature.code,
-            unit: "count",
+            meter: feature.code,
             limit: Number.isFinite(Number(feature.value)) ? Number(feature.value) : 0,
           }));
-        return { plan_id: planId, summary };
       };
 
 export async function adminGetPlanCreditsSummary(planId) {
-  return {
-    plan_id: planId,
-    credits: [
-      { meter: 'ai_tokens', limit: 100000, period: 'month' },
-      { meter: 'ai_messages', limit: 2000, period: 'month' },
-    ],
-  };
+  const credits = await adminGetPlanCredits(planId);
+  return { plan_id: planId, credits };
 }
 
 export const adminPutPlanFeatures =

--- a/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
+++ b/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
@@ -634,7 +634,6 @@ export default function AdminOrganizationsPage() {
         }
       } catch (err) {
         if (!cancelled) {
-          setItems([]);
           const message = err?.message || "Não foi possível carregar as organizações.";
           setError(message);
           toast({ title: "Erro ao carregar organizações", description: message });

--- a/frontend/src/pages/admin/plans/PlansPage.jsx
+++ b/frontend/src/pages/admin/plans/PlansPage.jsx
@@ -3,7 +3,7 @@ import {
   adminCreatePlan,
   adminDeletePlan,
   adminDuplicatePlan,
-  adminGetPlanCreditsSummary,
+  adminGetPlanCredits,
   adminListPlans,
   adminUpdatePlan,
   centsToBRL,
@@ -52,10 +52,10 @@ function PlanCreditsSummary({ planId, refreshKey }) {
     if (!planId) return;
     let alive = true;
     setState({ loading: true, credits: [], error: null });
-    adminGetPlanCreditsSummary(planId)
+    adminGetPlanCredits(planId)
       .then((res) => {
         if (!alive) return;
-        const credits = Array.isArray(res?.credits) ? res.credits : [];
+        const credits = Array.isArray(res) ? res : [];
         setState({ loading: false, credits, error: null });
       })
       .catch((err) => {
@@ -71,20 +71,24 @@ function PlanCreditsSummary({ planId, refreshKey }) {
 
   let content;
   if (state.loading) {
-    content = <p className="text-sm text-slate-500">Carregando créditos…</p>;
+    content = (
+      <div className="space-y-2">
+        <div className="h-4 w-1/3 animate-pulse rounded bg-slate-200" />
+        <div className="h-4 w-1/4 animate-pulse rounded bg-slate-200" />
+        <div className="h-4 w-1/5 animate-pulse rounded bg-slate-200" />
+      </div>
+    );
   } else if (state.error) {
     content = <p className="text-sm text-red-600">Erro ao carregar créditos.</p>;
   } else if (!state.credits.length) {
-    content = <p className="text-sm text-slate-500">Sem créditos configurados para este plano.</p>;
+    content = <p className="text-sm text-slate-500">Sem limites configurados</p>;
   } else {
     content = (
       <ul className="mt-2 space-y-1">
         {state.credits.map((credit) => (
           <li key={credit.meter} className="flex items-center justify-between text-sm">
             <span className="font-medium text-slate-700">{credit.meter}</span>
-            <span className="text-slate-600">
-              {credit.limit} / {credit.period || 'month'}
-            </span>
+            <span className="text-slate-600">{credit.limit}</span>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- update the admin orgs endpoint to derive active status from the stored column and accept status filters
- normalize the admin orgs client to handle the new payload shape and keep the table usable on failures
- expose plan credit limits through the admin API and refresh the plans page summary card UI

## Testing
- npm test -- AdminOrganizationsPage --runTestsByPath frontend/test/AdminOrganizationsPage.test.jsx *(fails: missing optional test dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dac6a540908327913fe15d0b0a95e4