### PR TITLE
Update admin organizations listing flow

### DIFF
--- a/backend/routes/admin/orgs.js
+++ b/backend/routes/admin/orgs.js
@@ -60,6 +60,10 @@ const db = {
 // GET /api/admin/orgs?status=active|inactive|all&q=foo
 router.get('/', async (req, res, next) => {
   try {
+    req.log?.info(
+      { route: 'admin.orgs.list', query: { status: req.query?.status, q: req.query?.q } },
+      'admin orgs list request',
+    );
     const rawStatus = String(req.query.status ?? 'active').toLowerCase();
     const status = StatusSchema.parse(rawStatus);
     const q = String(req.query.q ?? '').trim();
@@ -94,6 +98,13 @@ router.get('/', async (req, res, next) => {
     const { rows } = await query(sql, params);
     res.json({ items: rows ?? [] });
   } catch (err) {
+    req.log?.error(
+      {
+        route: 'admin.orgs.list',
+        err: { message: err?.message, code: err?.code },
+      },
+      'admin orgs list failed',
+    );
     next(err);
   }
 });

--- a/frontend/src/api/__mocks__/inboxApi.js
+++ b/frontend/src/api/__mocks__/inboxApi.js
@@ -322,7 +322,7 @@ async function _get(path, config = {}) {
       const target = `${org.name || ""} ${org.slug || ""} ${org.document_value || ""}`.toLowerCase();
       return target.includes(q);
     });
-    return res({ data: rows, count: rows.length });
+    return res({ items: rows, count: rows.length });
   }
 
   if (url === "/admin/plans") {
@@ -733,11 +733,14 @@ function callListAdminOrgs(status = "active", options = {}) {
 
 async function callAdminListOrgs(params = {}, options = {}) {
   const cfg = { ...(options || {}) };
-  const normalized = { status: 'active', ...(params || {}) };
+  const normalized = { status: 'active', q: '', ...(params || {}) };
   cfg.params = { ...(cfg.params || {}), status: normalized.status };
+  if (normalized.q) cfg.params.q = normalized.q;
   const response = await inboxApi.get(`/admin/orgs`, cfg);
   const payload = response?.data;
-  const list = Array.isArray(payload?.data)
+  const list = Array.isArray(payload?.items)
+    ? payload.items
+    : Array.isArray(payload?.data)
     ? payload.data
     : Array.isArray(payload)
     ? payload

--- a/frontend/src/api/inboxApi.js
+++ b/frontend/src/api/inboxApi.js
@@ -337,10 +337,14 @@ function withGlobalScope(options = {}) {
   return next;
 }
 
-export async function adminListOrgs(params = {}) {
-  const config = withGlobalScope({ params });
-  const { data } = await inboxApi.get(`/admin/orgs`, config);
-  const rows = Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : [];
+export async function adminListOrgs({ status = 'active', q = '' } = {}) {
+  const params = new URLSearchParams();
+  if (status) params.set('status', status);
+  if (q) params.set('q', q);
+  const search = params.toString();
+  const url = search ? `/admin/orgs?${search}` : '/admin/orgs';
+  const res = await client.get(url, withGlobalScope());
+  const rows = Array.isArray(res?.data?.items) ? res.data.items : [];
   return rows.map((org) => {
     const normalizedActive =
       typeof org?.is_active === 'boolean'

--- a/frontend/test/AdminOrganizationsPage.test.jsx
+++ b/frontend/test/AdminOrganizationsPage.test.jsx
@@ -51,9 +51,26 @@ test("carrega organizações ativas por padrão", async () => {
     });
   });
 
-  await waitFor(() => expect(adminListOrgs).toHaveBeenCalledWith({ status: "active" }));
+  await waitFor(() =>
+    expect(adminListOrgs).toHaveBeenCalledWith(expect.objectContaining({ status: "active", q: "" }))
+  );
   expect(await screen.findByText("Empresa A")).toBeInTheDocument();
   await waitFor(() => expect(screen.getByText("Empresa B")).toBeInTheDocument());
+});
+
+test("mostra estado vazio quando nenhuma organização é retornada", async () => {
+  adminListOrgs.mockResolvedValueOnce([]);
+
+  await act(async () => {
+    renderApp(<AdminOrganizationsPage />, {
+      route: "/admin/organizations",
+      user: { id: "admin", role: "SuperAdmin", roles: ["SuperAdmin"] },
+    });
+  });
+
+  await waitFor(() => expect(adminListOrgs).toHaveBeenCalled());
+  expect(await screen.findByText("Nenhuma organização.")).toBeInTheDocument();
+  expect(screen.queryByText("Não foi possível carregar as organizações.")).not.toBeInTheDocument();
 });
 
 test("edita dados básicos da organização", async () => {


### PR DESCRIPTION
## Summary
- add lightweight logging to the admin orgs listing route for observability
- update the admin API helper to consume the `{ items }` response and expose status/search parameters
- refresh the admin organizations page UI states, mocks, and tests to handle the new contract

## Testing
- npx jest --config jest.config.cjs --runTestsByPath test/AdminOrganizationsPage.test.jsx


------
https://chatgpt.com/codex/tasks/task_e_68db05403dcc83278f404ba5f18d139a