### PR TITLE
Add org membership routes and admin delete endpoint

### DIFF
--- a/frontend/src/api/inboxApi.js
+++ b/frontend/src/api/inboxApi.js
@@ -376,6 +376,14 @@ export async function patchAdminOrg(orgId, payload, options = {}) {
   return inboxApi.patch(`/admin/orgs/${orgId}`, payload, withGlobalScope(options));
 }
 
+export async function postAdminOrg(payload, options = {}) {
+  return inboxApi.post('/admin/orgs', payload, withGlobalScope(options));
+}
+
+export async function deleteAdminOrg(orgId, options = {}) {
+  return inboxApi.delete(`/admin/orgs/${orgId}`, withGlobalScope(options));
+}
+
 export async function putAdminOrgPlan(orgId, payload, options = {}) {
   return inboxApi.put(`/admin/orgs/${orgId}/plan`, payload, withGlobalScope(options));
 }


### PR DESCRIPTION
## Summary
- add GET /api/orgs/me and POST /api/orgs/switch to support the workspace switcher
- gate admin organization deletion behind SuperAdmin/Support and prevent removing the default slug
- expose helper API methods for creating and deleting organizations from the frontend client

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db2af998908327b28f6f85ffc920d8