### PR TITLE
feat: improve organization switching and admin management UX

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3,11 +3,13 @@ import adminOrgsRouter from './routes/admin/orgs.js';
 import adminOrgByIdRouter from './routes/admin/orgById.js';
 import adminPlansRouter from './routes/admin/plans.js';
 import { withOrgId } from './middleware/withOrgId.js';
+import utilsRouter from './routes/utils.js';
 
 const app = express();
 app.use(express.json());
 app.use('/api/admin/plans', adminPlansRouter);
 app.use('/api/admin/orgs', adminOrgsRouter);
 app.use('/api/admin/orgs/:orgId', withOrgId, adminOrgByIdRouter);
+app.use('/api/utils', utilsRouter);
 
 export default app;

--- a/backend/routes/utils.js
+++ b/backend/routes/utils.js
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import authRequired from '../middleware/auth.js';
+import { lookupCNPJ, lookupCEP } from '../services/brasilapi.js';
+
+const router = Router();
+
+router.get('/cnpj/:cnpj', authRequired, async (req, res) => {
+  try {
+    const data = await lookupCNPJ(req.params.cnpj);
+    return res.json(data);
+  } catch (e) {
+    return res.status(422).json({ error: e.message });
+  }
+});
+
+router.get('/cep/:cep', authRequired, async (req, res) => {
+  try {
+    const data = await lookupCEP(req.params.cep);
+    return res.json(data);
+  } catch (e) {
+    return res.status(422).json({ error: e.message });
+  }
+});
+
+export default router;

--- a/backend/services/brasilapi.js
+++ b/backend/services/brasilapi.js
@@ -1,0 +1,46 @@
+import fetch from 'node-fetch';
+
+const onlyDigits = (s = '') => (s || '').toString().replace(/\D+/g, '');
+
+export async function lookupCNPJ(cnpj) {
+  const doc = onlyDigits(cnpj);
+  if (doc.length !== 14) throw new Error('invalid_cnpj');
+  const r = await fetch(`https://brasilapi.com.br/api/cnpj/v1/${doc}`);
+  if (!r.ok) throw new Error('cnpj_lookup_failed');
+  const j = await r.json();
+  return {
+    cnpj: j.cnpj || doc,
+    razao_social: j.razao_social || j.nome_fantasia || '',
+    nome_fantasia: j.nome_fantasia || '',
+    email: j.email || null,
+    endereco: {
+      cep: onlyDigits(j.cep),
+      logradouro: j.logradouro || j.descricao_tipo_de_logradouro || '',
+      numero: j.numero || '',
+      complemento: j.complemento || '',
+      bairro: j.bairro || '',
+      cidade: j.municipio || j.cidade || '',
+      uf: j.uf || '',
+      country: 'BR',
+    },
+    ie: j.inscr_estadual || null,
+    site: j.site || null,
+  };
+}
+
+export async function lookupCEP(cep) {
+  const code = onlyDigits(cep);
+  if (code.length !== 8) throw new Error('invalid_cep');
+  const r = await fetch(`https://viacep.com.br/ws/${code}/json/`);
+  if (!r.ok) throw new Error('cep_lookup_failed');
+  const j = await r.json();
+  if (j.erro) throw new Error('cep_not_found');
+  return {
+    cep: code,
+    logradouro: j.logradouro || '',
+    bairro: j.bairro || '',
+    cidade: j.localidade || '',
+    uf: j.uf || '',
+    country: 'BR',
+  };
+}

--- a/backend/validation/orgSchemas.cjs
+++ b/backend/validation/orgSchemas.cjs
@@ -43,9 +43,8 @@ const OrgCreateSchema = z
         nome: z.string().min(2),
         cpf: z
           .string()
-          .optional()
-          .nullable()
-          .refine((v) => !v || br.isValidCPF(v), "CPF inválido"),
+          .min(1, "CPF obrigatório")
+          .refine((v) => br.isValidCPF(v), "CPF inválido"),
         email: z.string().email().optional().nullable(),
         phone_e164: z
           .string()

--- a/frontend/src/api/inboxApi.js
+++ b/frontend/src/api/inboxApi.js
@@ -384,6 +384,25 @@ export async function deleteAdminOrg(orgId, options = {}) {
   return inboxApi.delete(`/admin/orgs/${orgId}`, withGlobalScope(options));
 }
 
+export async function getMyOrgs() {
+  const { data } = await client.get('/orgs/me');
+  return data;
+}
+
+export async function switchOrg(orgId) {
+  await client.post('/orgs/switch', { orgId });
+}
+
+export async function lookupCNPJ(cnpj) {
+  const { data } = await client.get(`/utils/cnpj/${encodeURIComponent(cnpj)}`);
+  return data;
+}
+
+export async function lookupCEP(cep) {
+  const { data } = await client.get(`/utils/cep/${encodeURIComponent(cep)}`);
+  return data;
+}
+
 export async function putAdminOrgPlan(orgId, payload, options = {}) {
   return inboxApi.put(`/admin/orgs/${orgId}/plan`, payload, withGlobalScope(options));
 }

--- a/frontend/src/components/WorkspaceSwitcher.jsx
+++ b/frontend/src/components/WorkspaceSwitcher.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import inboxApi, { adminListOrgs } from "@/api/inboxApi";
+import { adminListOrgs, getMyOrgs, switchOrg } from "@/api/inboxApi";
 import { useAuth } from "@/contexts/AuthContext";
 import { hasGlobalRole } from "@/auth/roles";
 
@@ -32,7 +32,7 @@ export default function WorkspaceSwitcher({ collapsed = false }) {
           setCurrent(nextCurrent);
           if (nextCurrent) localStorage.setItem('org_id', nextCurrent);
         } else {
-          const { data } = await inboxApi.get('/orgs/me');
+          const data = await getMyOrgs();
           if (!alive) return;
 
           const list = Array.isArray(data?.orgs) ? data.orgs : [];
@@ -60,7 +60,7 @@ export default function WorkspaceSwitcher({ collapsed = false }) {
     setCurrent(orgId);
     localStorage.setItem('org_id', orgId); // mantém WS e outras áreas em sincronia
     try {
-      await inboxApi.post('/orgs/switch', { orgId });
+      await switchOrg(orgId);
     } catch {
       // ignora erros: a página vai recarregar de qualquer jeito
     }

--- a/frontend/src/pages/admin/organizations/AdminOrgEditModal.jsx
+++ b/frontend/src/pages/admin/organizations/AdminOrgEditModal.jsx
@@ -1,510 +1,770 @@
-import React, { useEffect, useMemo, useState } from "react";
-import inboxApi, {
+import { useEffect, useMemo, useState } from "react";
+import {
+  lookupCEP as apiLookupCEP,
+  lookupCNPJ as apiLookupCNPJ,
   patchAdminOrg,
-  patchAdminOrgCredits,
-  putAdminOrgPlan,
-} from "../../../api/inboxApi";
-
-function toInputDate(value) {
-  if (!value) return "";
-  try {
-    const d = new Date(value);
-    if (Number.isNaN(d.getTime())) return String(value).slice(0, 10);
-    return d.toISOString().slice(0, 10);
-  } catch {
-    return "";
-  }
-}
+  postAdminOrg,
+} from "@/api/inboxApi";
+import { useAuth } from "@/contexts/AuthContext";
+import { hasGlobalRole } from "@/auth/roles";
+import {
+  isValidCEP,
+  isValidCNPJ,
+  isValidCPF,
+  isValidUF,
+  onlyDigits,
+} from "@/validation/br";
 
 const STATUS_OPTIONS = [
   { value: "active", label: "Ativa" },
   { value: "inactive", label: "Inativa" },
+  { value: "suspended", label: "Suspensa" },
+  { value: "canceled", label: "Cancelada" },
 ];
 
-export default function AdminOrgEditModal({ open, org, onClose, onSaved }) {
-  const [form, setForm] = useState({
-    name: "",
-    slug: "",
+const WHATSAPP_MODES = [
+  { value: "none", label: "Desligado" },
+  { value: "baileys", label: "Baileys" },
+];
+
+const emptyForm = {
+  name: "",
+  slug: "",
+  status: "active",
+  cnpj: "",
+  razao_social: "",
+  nome_fantasia: "",
+  email: "",
+  phone_e164: "",
+  site: "",
+  ie: "",
+  ie_isento: false,
+  endereco: {
+    cep: "",
+    logradouro: "",
+    numero: "",
+    complemento: "",
+    bairro: "",
+    cidade: "",
+    uf: "",
+    country: "BR",
+  },
+  responsavel: {
+    nome: "",
+    cpf: "",
     email: "",
-    phone: "",
-    status: "active",
-    plan_id: "",
-    trial_ends_at: "",
-    document_type: "",
-    document_value: "",
-    whatsapp_baileys_enabled: false,
-    whatsapp_baileys_status: "",
-    whatsapp_baileys_phone: "",
-    photo_url: "",
-    metaText: "",
-  });
-  const [plans, setPlans] = useState([]);
-  const [plansLoading, setPlansLoading] = useState(false);
-  const [error, setError] = useState("");
+    phone_e164: "",
+  },
+  whatsapp_baileys_enabled: false,
+  whatsapp_mode: "none",
+  whatsapp_baileys_status: "",
+  whatsapp_baileys_phone: "",
+};
+
+function mapOrgToForm(org) {
+  if (!org) return { ...emptyForm };
+  return {
+    ...emptyForm,
+    name: org.name || org.razao_social || "",
+    slug: org.slug || "",
+    status: org.status || "active",
+    cnpj: org.cnpj || "",
+    razao_social: org.razao_social || "",
+    nome_fantasia: org.nome_fantasia || "",
+    email: org.email || "",
+    phone_e164: org.phone_e164 || org.phone || "",
+    site: org.site || "",
+    ie: org.ie || "",
+    ie_isento: !!org.ie_isento,
+    endereco: {
+      cep: org.cep || "",
+      logradouro: org.logradouro || "",
+      numero: org.numero || "",
+      complemento: org.complemento || "",
+      bairro: org.bairro || "",
+      cidade: org.cidade || "",
+      uf: org.uf || "",
+      country: org.country || "BR",
+    },
+    responsavel: {
+      nome: org.resp_nome || "",
+      cpf: org.resp_cpf || "",
+      email: org.resp_email || "",
+      phone_e164: org.resp_phone_e164 || "",
+    },
+    whatsapp_baileys_enabled: !!org.whatsapp_baileys_enabled,
+    whatsapp_mode: org.whatsapp_mode || "none",
+    whatsapp_baileys_status: org.whatsapp_baileys_status || "",
+    whatsapp_baileys_phone: org.whatsapp_baileys_phone || "",
+  };
+}
+
+function readError(errors, field) {
+  return errors[field] || "";
+}
+
+export default function AdminOrgEditModal({ open, mode = "edit", org, onClose, onSaved }) {
+  const { user } = useAuth();
+  const canManageBaileys = hasGlobalRole(["SuperAdmin", "Support"], user);
+
+  const [form, setForm] = useState({ ...emptyForm });
+  const [errors, setErrors] = useState({});
   const [saving, setSaving] = useState(false);
   const [feedback, setFeedback] = useState("");
+  const [cnpjLookupLoading, setCnpjLookupLoading] = useState(false);
+  const [cepLookupLoading, setCepLookupLoading] = useState(false);
+  const [globalError, setGlobalError] = useState("");
 
-  const [historyForm, setHistoryForm] = useState({
-    plan_id: "",
-    status: "active",
-    start_at: "",
-    end_at: "",
-    trial_ends_at: "",
-    meta: "",
-  });
-  const [historyMessage, setHistoryMessage] = useState("");
-  const [historyError, setHistoryError] = useState("");
-  const [historySaving, setHistorySaving] = useState(false);
-
-  const [creditsForm, setCreditsForm] = useState({
-    feature_code: "",
-    delta: "",
-    expires_at: "",
-    source: "manual",
-    meta: "",
-  });
-  const [creditsMessage, setCreditsMessage] = useState("");
-  const [creditsError, setCreditsError] = useState("");
-  const [creditsSaving, setCreditsSaving] = useState(false);
-
-  const planMap = useMemo(() => {
-    return plans.reduce((acc, plan) => {
-      if (plan?.id) acc[plan.id] = plan.name || plan.label || plan.title || plan.id;
-      return acc;
-    }, {});
-  }, [plans]);
+  const isCreate = mode === "create";
 
   useEffect(() => {
     if (!open) return;
-    let cancelled = false;
-    (async () => {
-      setPlansLoading(true);
-      try {
-        const { data } = await inboxApi.get("/public/plans", { meta: { noAuth: true } });
-        if (cancelled) return;
-        const items = Array.isArray(data?.items) ? data.items : [];
-        setPlans(items);
-      } catch (e) {
-        if (!cancelled) {
-          setPlans([]);
-        }
-      } finally {
-        if (!cancelled) setPlansLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open || !org) return;
-    setError("");
+    setForm(mapOrgToForm(org));
+    setErrors({});
     setFeedback("");
-    setHistoryMessage("");
-    setHistoryError("");
-    setCreditsMessage("");
-    setCreditsError("");
-
-    setForm({
-      name: org.name || "",
-      slug: org.slug || "",
-      email: org.email || "",
-      phone: org.phone || "",
-      status: org.status || "active",
-      plan_id: org.plan_id || "",
-      trial_ends_at: toInputDate(org.trial_ends_at),
-      document_type: org.document_type || "",
-      document_value: org.document_value || "",
-      whatsapp_baileys_enabled: !!org.whatsapp_baileys_enabled,
-      whatsapp_baileys_status: org.whatsapp_baileys_status || "",
-      whatsapp_baileys_phone: org.whatsapp_baileys_phone || "",
-      photo_url: org.photo_url || "",
-      metaText: org.meta ? JSON.stringify(org.meta, null, 2) : "",
-    });
-    setHistoryForm((prev) => ({
-      ...prev,
-      plan_id: org.plan_id || "",
-      status: "active",
-      start_at: "",
-      end_at: "",
-      trial_ends_at: toInputDate(org.trial_ends_at),
-      meta: "",
-    }));
-    setCreditsForm({ feature_code: "", delta: "", expires_at: "", source: "manual", meta: "" });
+    setGlobalError("");
+    setCnpjLookupLoading(false);
+    setCepLookupLoading(false);
   }, [open, org]);
 
-  if (!open || !org) return null;
+  const statusOptions = useMemo(() => STATUS_OPTIONS, []);
 
-  const close = () => {
-    if (saving || historySaving || creditsSaving) return;
-    onClose?.();
-  };
+  if (!open) return null;
 
-  const handleField = (field) => (event) => {
-    const value = event?.target?.type === "checkbox" ? event.target.checked : event?.target?.value;
+  const setField = (field, value) => {
     setForm((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
   };
 
-  const handleHistoryField = (field) => (event) => {
-    const value = event?.target?.value ?? "";
-    setHistoryForm((prev) => ({ ...prev, [field]: value }));
+  const setNestedField = (section, field, value) => {
+    setForm((prev) => ({
+      ...prev,
+      [section]: {
+        ...prev[section],
+        [field]: value,
+      },
+    }));
+    const key = `${section}.${field}`;
+    setErrors((prev) => {
+      if (!prev[key]) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
   };
 
-  const handleCreditsField = (field) => (event) => {
-    const value = event?.target?.value ?? "";
-    setCreditsForm((prev) => ({ ...prev, [field]: value }));
+  const handleInputChange = (field) => (event) => {
+    setField(field, event.target.value);
   };
 
-  const submit = async (event) => {
-    event?.preventDefault();
-    setError("");
-    setFeedback("");
+  const handleCheckboxChange = (field) => (event) => {
+    setField(field, event.target.checked);
+  };
 
-    if (!form.name.trim()) {
-      setError("Nome da organização é obrigatório.");
+  const handleAddressChange = (field) => (event) => {
+    setNestedField("endereco", field, event.target.value);
+  };
+
+  const handleResponsavelChange = (field) => (event) => {
+    setNestedField("responsavel", field, event.target.value);
+  };
+
+  const applyCnpjData = (data) => {
+    if (!data) return;
+    setForm((prev) => ({
+      ...prev,
+      cnpj: data.cnpj || prev.cnpj,
+      razao_social: data.razao_social || prev.razao_social,
+      nome_fantasia: data.nome_fantasia || prev.nome_fantasia,
+      email: data.email || prev.email,
+      endereco: {
+        ...prev.endereco,
+        cep: data.endereco?.cep || prev.endereco.cep,
+        logradouro: data.endereco?.logradouro || prev.endereco.logradouro,
+        numero: data.endereco?.numero || prev.endereco.numero,
+        complemento: data.endereco?.complemento || prev.endereco.complemento,
+        bairro: data.endereco?.bairro || prev.endereco.bairro,
+        cidade: data.endereco?.cidade || prev.endereco.cidade,
+        uf: data.endereco?.uf || prev.endereco.uf,
+        country: data.endereco?.country || prev.endereco.country || "BR",
+      },
+    }));
+  };
+
+  const applyCepData = (data) => {
+    if (!data) return;
+    setForm((prev) => ({
+      ...prev,
+      endereco: {
+        ...prev.endereco,
+        cep: data.cep || prev.endereco.cep,
+        logradouro: data.logradouro || prev.endereco.logradouro,
+        bairro: data.bairro || prev.endereco.bairro,
+        cidade: data.cidade || prev.endereco.cidade,
+        uf: data.uf || prev.endereco.uf,
+        country: data.country || prev.endereco.country || "BR",
+      },
+    }));
+  };
+
+  const handleCnpjBlur = async () => {
+    const digits = onlyDigits(form.cnpj);
+    if (!digits) return;
+    if (!isValidCNPJ(digits)) {
+      setErrors((prev) => ({ ...prev, cnpj: "CNPJ inválido" }));
       return;
     }
-
-    let metaPayload;
-    if (form.metaText && form.metaText.trim()) {
-      try {
-        metaPayload = JSON.parse(form.metaText);
-      } catch (e) {
-        setError("Meta deve ser um JSON válido.");
-        return;
-      }
+    setCnpjLookupLoading(true);
+    try {
+      const data = await apiLookupCNPJ(digits);
+      applyCnpjData(data);
+      setFeedback("Dados do CNPJ preenchidos automaticamente.");
+    } catch (err) {
+      const message = err?.message || "Não foi possível buscar o CNPJ.";
+      setGlobalError(message);
+    } finally {
+      setCnpjLookupLoading(false);
     }
+  };
+
+  const handleCepBlur = async () => {
+    const digits = onlyDigits(form.endereco.cep);
+    if (!digits) return;
+    if (!isValidCEP(digits)) {
+      setErrors((prev) => ({ ...prev, "endereco.cep": "CEP inválido" }));
+      return;
+    }
+    setCepLookupLoading(true);
+    try {
+      const data = await apiLookupCEP(digits);
+      applyCepData(data);
+    } catch (err) {
+      const message = err?.message || "Não foi possível buscar o CEP.";
+      setGlobalError(message);
+    } finally {
+      setCepLookupLoading(false);
+    }
+  };
+
+  const validateForm = () => {
+    const nextErrors = {};
+    if (!form.name.trim()) nextErrors.name = "Nome é obrigatório";
+
+    const cnpjDigits = onlyDigits(form.cnpj);
+    if (!cnpjDigits || !isValidCNPJ(cnpjDigits)) nextErrors.cnpj = "CNPJ inválido";
+
+    if (!form.responsavel.nome.trim()) nextErrors["responsavel.nome"] = "Informe o nome do responsável";
+
+    const cpfDigits = onlyDigits(form.responsavel.cpf);
+    if (!cpfDigits || !isValidCPF(cpfDigits)) nextErrors["responsavel.cpf"] = "CPF inválido";
+
+    const cepDigits = onlyDigits(form.endereco.cep);
+    if (!cepDigits || !isValidCEP(cepDigits)) nextErrors["endereco.cep"] = "CEP inválido";
+
+    if (!form.endereco.logradouro.trim()) nextErrors["endereco.logradouro"] = "Logradouro obrigatório";
+    if (!form.endereco.numero.trim()) nextErrors["endereco.numero"] = "Número obrigatório";
+    if (!form.endereco.bairro.trim()) nextErrors["endereco.bairro"] = "Bairro obrigatório";
+    if (!form.endereco.cidade.trim()) nextErrors["endereco.cidade"] = "Cidade obrigatória";
+    if (!form.endereco.uf.trim() || !isValidUF(form.endereco.uf))
+      nextErrors["endereco.uf"] = "UF inválida";
+
+    if (!form.email && !form.phone_e164)
+      nextErrors.email = "Informe e-mail ou telefone da empresa";
+
+    if (!form.responsavel.email && !form.responsavel.phone_e164)
+      nextErrors["responsavel.email"] = "Responsável: informe e-mail ou telefone";
+
+    if (form.whatsapp_baileys_enabled && !form.whatsapp_baileys_phone)
+      nextErrors.whatsapp_baileys_phone = "Informe o telefone do WhatsApp";
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const buildCreatePayload = () => {
+    const cnpjDigits = onlyDigits(form.cnpj);
+    const cepDigits = onlyDigits(form.endereco.cep);
+    const cpfDigits = onlyDigits(form.responsavel.cpf);
+    return {
+      cnpj: cnpjDigits,
+      razao_social: form.razao_social || form.name,
+      nome_fantasia: form.nome_fantasia || form.name,
+      ie: form.ie || null,
+      ie_isento: !!form.ie_isento,
+      site: form.site || null,
+      email: form.email || null,
+      phone_e164: form.phone_e164 || null,
+      status: form.status || "active",
+      endereco: {
+        cep: cepDigits,
+        logradouro: form.endereco.logradouro,
+        numero: form.endereco.numero,
+        complemento: form.endereco.complemento || null,
+        bairro: form.endereco.bairro,
+        cidade: form.endereco.cidade,
+        uf: form.endereco.uf.toUpperCase(),
+        country: form.endereco.country || "BR",
+      },
+      responsavel: {
+        nome: form.responsavel.nome,
+        cpf: cpfDigits,
+        email: form.responsavel.email || null,
+        phone_e164: form.responsavel.phone_e164 || null,
+      },
+    };
+  };
+
+  const buildUpdatePayload = () => {
+    const cepDigits = onlyDigits(form.endereco.cep);
+    const cpfDigits = onlyDigits(form.responsavel.cpf);
+    const payload = {
+      name: form.name.trim(),
+      slug: form.slug.trim() || null,
+      status: form.status,
+      email: form.email || null,
+      phone_e164: form.phone_e164 || null,
+      razao_social: form.razao_social || null,
+      nome_fantasia: form.nome_fantasia || null,
+      site: form.site || null,
+      ie: form.ie || null,
+      ie_isento: !!form.ie_isento,
+      cep: cepDigits || null,
+      logradouro: form.endereco.logradouro || null,
+      numero: form.endereco.numero || null,
+      complemento: form.endereco.complemento || null,
+      bairro: form.endereco.bairro || null,
+      cidade: form.endereco.cidade || null,
+      uf: form.endereco.uf ? form.endereco.uf.toUpperCase() : null,
+      country: form.endereco.country || "BR",
+      resp_nome: form.responsavel.nome || null,
+      resp_cpf: cpfDigits || null,
+      resp_email: form.responsavel.email || null,
+      resp_phone_e164: form.responsavel.phone_e164 || null,
+    };
+
+    if (canManageBaileys) {
+      payload.whatsapp_baileys_enabled = !!form.whatsapp_baileys_enabled;
+      payload.whatsapp_mode = form.whatsapp_mode || "none";
+      payload.whatsapp_baileys_status = form.whatsapp_baileys_status || null;
+      payload.whatsapp_baileys_phone = form.whatsapp_baileys_phone || null;
+    }
+
+    return payload;
+  };
+
+  const handleSubmit = async (event) => {
+    event?.preventDefault();
+    setFeedback("");
+    setGlobalError("");
+    if (!validateForm()) return;
 
     setSaving(true);
     try {
-      const payload = {
-        name: form.name.trim(),
-        slug: form.slug.trim() || null,
-        email: form.email.trim() || null,
-        phone: form.phone.trim() || null,
-        status: form.status,
-        plan_id: form.plan_id || null,
-        trial_ends_at: form.trial_ends_at || null,
-        document_type: form.document_type || null,
-        document_value: form.document_value.trim() || null,
-        whatsapp_baileys_enabled: !!form.whatsapp_baileys_enabled,
-        whatsapp_baileys_status: form.whatsapp_baileys_status || null,
-        whatsapp_baileys_phone: form.whatsapp_baileys_phone.trim() || null,
-        photo_url: form.photo_url.trim() || null,
-      };
-      if (metaPayload !== undefined) {
-        payload.meta = metaPayload;
-      } else if (form.metaText === "") {
-        payload.meta = {};
+      if (isCreate) {
+        const payload = buildCreatePayload();
+        const response = await postAdminOrg(payload);
+        const createdId = response?.data?.id || null;
+        setFeedback("Organização criada com sucesso.");
+        onSaved?.({ id: createdId });
+      } else if (org?.id) {
+        const payload = buildUpdatePayload();
+        await patchAdminOrg(org.id, payload);
+        setFeedback("Organização atualizada.");
+        onSaved?.();
       }
-
-      const { data } = await patchAdminOrg(org.id, payload);
-
-      if (data?.org) {
-        setForm((prev) => ({
-          ...prev,
-          plan_id: data.org.plan_id || "",
-          trial_ends_at: toInputDate(data.org.trial_ends_at),
-        }));
-        onSaved?.({
-          ...org,
-          ...data.org,
-          plan_name: data.org.plan_name || planMap[data.org.plan_id] || org.plan_name,
-        });
-      }
-
-      setFeedback("Dados atualizados com sucesso.");
-    } catch (e) {
-      const message = e?.response?.data?.error || e?.message || "Falha ao salvar.";
-      setError(message);
+    } catch (err) {
+      const message = err?.response?.data?.error || err?.message || "Falha ao salvar.";
+      setGlobalError(message);
     } finally {
       setSaving(false);
     }
   };
 
-  const submitPlanHistory = async () => {
-    setHistoryError("");
-    setHistoryMessage("");
-
-    const nextPlanId = historyForm.plan_id || form.plan_id || null;
-    if (!nextPlanId) {
-      setHistoryError("Informe um plano para registrar o histórico.");
-      return;
-    }
-
-    let metaPayload;
-    if (historyForm.meta && historyForm.meta.trim()) {
-      try {
-        metaPayload = JSON.parse(historyForm.meta);
-      } catch (e) {
-        setHistoryError("Meta (histórico) deve ser JSON válido.");
-        return;
-      }
-    }
-
-    setHistorySaving(true);
-    try {
-      await putAdminOrgPlan(org.id, {
-        plan_id: nextPlanId,
-        status: historyForm.status || "active",
-        start_at: historyForm.start_at || null,
-        end_at: historyForm.end_at || null,
-        trial_ends_at: historyForm.trial_ends_at || null,
-        meta: metaPayload,
-      });
-
-      const nextTrial = historyForm.trial_ends_at || form.trial_ends_at || null;
-      setForm((prev) => ({ ...prev, plan_id: nextPlanId || "", trial_ends_at: nextTrial || "" }));
-      setHistoryForm((prev) => ({ ...prev, plan_id: nextPlanId || "", meta: "" }));
-
-      onSaved?.({
-        ...org,
-        plan_id: nextPlanId,
-        trial_ends_at: nextTrial,
-        plan_name: planMap[nextPlanId] || org.plan_name,
-      });
-
-      setHistoryMessage("Histórico registrado com sucesso.");
-    } catch (e) {
-      const message = e?.response?.data?.error || e?.message || "Falha ao registrar histórico.";
-      setHistoryError(message);
-    } finally {
-      setHistorySaving(false);
-    }
-  };
-
-  const submitCredits = async () => {
-    setCreditsError("");
-    setCreditsMessage("");
-
-    if (!creditsForm.feature_code.trim()) {
-      setCreditsError("Informe o código do recurso.");
-      return;
-    }
-    if (!creditsForm.delta) {
-      setCreditsError("Informe o delta de créditos.");
-      return;
-    }
-
-    let metaPayload;
-    if (creditsForm.meta && creditsForm.meta.trim()) {
-      try {
-        metaPayload = JSON.parse(creditsForm.meta);
-      } catch (e) {
-        setCreditsError("Meta (créditos) deve ser JSON válido.");
-        return;
-      }
-    }
-
-    setCreditsSaving(true);
-    try {
-      await patchAdminOrgCredits(org.id, {
-        feature_code: creditsForm.feature_code.trim(),
-        delta: Number(creditsForm.delta),
-        expires_at: creditsForm.expires_at || null,
-        source: creditsForm.source || null,
-        meta: metaPayload,
-      });
-
-      setCreditsMessage("Crédito registrado com sucesso.");
-      setCreditsForm({ feature_code: "", delta: "", expires_at: "", source: creditsForm.source || "manual", meta: "" });
-    } catch (e) {
-      const message = e?.response?.data?.error || e?.message || "Falha ao registrar créditos.";
-      setCreditsError(message);
-    } finally {
-      setCreditsSaving(false);
-    }
+  const handleClose = () => {
+    if (saving) return;
+    onClose?.();
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
-      <div className="w-full max-w-4xl rounded-xl bg-white shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4">
+      <div className="w-full max-w-4xl overflow-hidden rounded-xl bg-white shadow-xl">
         <div className="flex items-center justify-between border-b px-6 py-4">
           <div>
-            <h2 className="text-xl font-semibold">Editar organização</h2>
-            <p className="text-sm text-gray-500">{org.name}</p>
+            <h2 className="text-lg font-semibold">
+              {isCreate ? "Nova organização" : "Editar organização"}
+            </h2>
+            {!isCreate && org?.name && <p className="text-sm text-gray-500">{org.name}</p>}
           </div>
           <button
             type="button"
-            onClick={close}
+            onClick={handleClose}
             className="text-sm text-gray-500 hover:text-gray-700"
+            disabled={saving}
           >
             Fechar
           </button>
         </div>
 
-        <form onSubmit={submit} className="space-y-6 px-6 py-5">
-          {error && <div className="rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>}
-          {feedback && <div className="rounded border border-emerald-300 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{feedback}</div>}
+        <form onSubmit={handleSubmit} className="space-y-6 px-6 py-5">
+          {globalError && (
+            <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{globalError}</div>
+          )}
+          {feedback && (
+            <div className="rounded border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{feedback}</div>
+          )}
 
-          <section>
-            <h3 className="text-lg font-semibold">Dados básicos</h3>
-            <div className="mt-3 grid gap-3 md:grid-cols-2">
+          <section className="space-y-3">
+            <h3 className="text-base font-semibold">Dados básicos</h3>
+            <div className="grid gap-3 md:grid-cols-2">
               <label className="text-sm">
-                <span className="block text-gray-600">Nome</span>
+                <span className="text-gray-600">Nome</span>
                 <input
                   type="text"
                   className="mt-1 w-full rounded border px-3 py-2"
                   value={form.name}
-                  onChange={handleField("name")}
+                  onChange={handleInputChange("name")}
                   required
                 />
+                {readError(errors, "name") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "name")}</span>
+                )}
               </label>
               <label className="text-sm">
-                <span className="block text-gray-600">Slug</span>
+                <span className="text-gray-600">Slug</span>
                 <input
                   type="text"
                   className="mt-1 w-full rounded border px-3 py-2"
                   value={form.slug}
-                  onChange={handleField("slug")}
+                  onChange={handleInputChange("slug")}
                 />
               </label>
               <label className="text-sm">
-                <span className="block text-gray-600">E-mail</span>
-                <input
-                  type="email"
-                  className="mt-1 w-full rounded border px-3 py-2"
-                  value={form.email}
-                  onChange={handleField("email")}
-                />
-              </label>
-              <label className="text-sm">
-                <span className="block text-gray-600">Telefone</span>
-                <input
-                  type="text"
-                  className="mt-1 w-full rounded border px-3 py-2"
-                  value={form.phone}
-                  onChange={handleField("phone")}
-                />
-              </label>
-              <label className="text-sm">
-                <span className="block text-gray-600">Tipo do documento</span>
+                <span className="text-gray-600">Status</span>
                 <select
                   className="mt-1 w-full rounded border px-3 py-2"
-                  value={form.document_type}
-                  onChange={handleField("document_type")}
+                  value={form.status}
+                  onChange={handleInputChange("status")}
                 >
-                  <option value="">—</option>
-                  <option value="CNPJ">CNPJ</option>
-                  <option value="CPF">CPF</option>
+                  {statusOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
                 </select>
-              </label>
-              <label className="text-sm">
-                <span className="block text-gray-600">Documento</span>
-                <input
-                  type="text"
-                  className="mt-1 w-full rounded border px-3 py-2"
-                  value={form.document_value}
-                  onChange={handleField("document_value")}
-                />
-              </label>
-              <label className="text-sm">
-                <span className="block text-gray-600">Foto / Logo (URL)</span>
-                <input
-                  type="url"
-                  className="mt-1 w-full rounded border px-3 py-2"
-                  value={form.photo_url}
-                  onChange={handleField("photo_url")}
-                />
               </label>
             </div>
           </section>
 
-          <section>
-            <h3 className="text-lg font-semibold">Plano e status</h3>
-            <div className="mt-3 grid gap-3 md:grid-cols-2">
+          <section className="space-y-3">
+            <h3 className="text-base font-semibold">Empresa</h3>
+            <div className="grid gap-3 md:grid-cols-2">
               <label className="text-sm">
-                <span className="block text-gray-600">Status</span>
-                <select
-                  className="mt-1 w-full rounded border px-3 py-2"
-                  value={form.status}
-                  onChange={handleField("status")}
-                >
-                  {STATUS_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </label>
-              <label className="text-sm">
-                <span className="block text-gray-600">Plano atual</span>
-                <select
-                  className="mt-1 w-full rounded border px-3 py-2"
-                  value={form.plan_id || ""}
-                  onChange={handleField("plan_id")}
-                  disabled={plansLoading}
-                >
-                  <option value="">— Sem plano —</option>
-                  {plans.map((plan) => (
-                    <option key={plan.id} value={plan.id}>
-                      {plan.name || plan.label || plan.id}
-                    </option>
-                  ))}
-                  {form.plan_id && !planMap[form.plan_id] && (
-                    <option value={form.plan_id}>{form.plan_id}</option>
-                  )}
-                </select>
-              </label>
-              <label className="text-sm">
-                <span className="block text-gray-600">Trial até</span>
+                <span className="text-gray-600">CNPJ</span>
                 <input
-                  type="date"
+                  type="text"
                   className="mt-1 w-full rounded border px-3 py-2"
-                  value={form.trial_ends_at || ""}
-                  onChange={handleField("trial_ends_at")}
+                  value={form.cnpj}
+                  onChange={handleInputChange("cnpj")}
+                  onBlur={handleCnpjBlur}
+                  placeholder="00.000.000/0000-00"
+                />
+                {cnpjLookupLoading && (
+                  <span className="mt-1 block text-xs text-gray-500">Buscando dados…</span>
+                )}
+                {readError(errors, "cnpj") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "cnpj")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Razão social</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.razao_social}
+                  onChange={handleInputChange("razao_social")}
+                />
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Nome fantasia</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.nome_fantasia}
+                  onChange={handleInputChange("nome_fantasia")}
+                />
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Site</span>
+                <input
+                  type="url"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.site}
+                  onChange={handleInputChange("site")}
+                  placeholder="https://"
+                />
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">E-mail</span>
+                <input
+                  type="email"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.email}
+                  onChange={handleInputChange("email")}
+                />
+                {readError(errors, "email") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "email")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Telefone (E.164)</span>
+                <input
+                  type="tel"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.phone_e164}
+                  onChange={handleInputChange("phone_e164")}
+                  placeholder="+5511999999999"
+                />
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Inscrição estadual</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.ie}
+                  onChange={handleInputChange("ie")}
                 />
               </label>
               <label className="mt-6 flex items-center gap-2 text-sm text-gray-600">
                 <input
                   type="checkbox"
-                  checked={form.whatsapp_baileys_enabled}
-                  onChange={handleField("whatsapp_baileys_enabled")}
+                  checked={form.ie_isento}
+                  onChange={handleCheckboxChange("ie_isento")}
                   className="h-4 w-4"
                 />
-                WhatsApp Baileys habilitado
+                IE isento
               </label>
             </div>
-            <div className="mt-3 grid gap-3 md:grid-cols-3">
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="text-base font-semibold">Endereço</h3>
+            <div className="grid gap-3 md:grid-cols-2">
               <label className="text-sm">
-                <span className="block text-gray-600">Status Baileys</span>
+                <span className="text-gray-600">CEP</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.endereco.cep}
+                  onChange={handleAddressChange("cep")}
+                  onBlur={handleCepBlur}
+                  placeholder="00000-000"
+                />
+                {cepLookupLoading && (
+                  <span className="mt-1 block text-xs text-gray-500">Carregando endereço…</span>
+                )}
+                {readError(errors, "endereco.cep") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "endereco.cep")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Logradouro</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.endereco.logradouro}
+                  onChange={handleAddressChange("logradouro")}
+                />
+                {readError(errors, "endereco.logradouro") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "endereco.logradouro")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Número</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.endereco.numero}
+                  onChange={handleAddressChange("numero")}
+                />
+                {readError(errors, "endereco.numero") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "endereco.numero")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Complemento</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.endereco.complemento}
+                  onChange={handleAddressChange("complemento")}
+                />
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Bairro</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.endereco.bairro}
+                  onChange={handleAddressChange("bairro")}
+                />
+                {readError(errors, "endereco.bairro") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "endereco.bairro")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Cidade</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.endereco.cidade}
+                  onChange={handleAddressChange("cidade")}
+                />
+                {readError(errors, "endereco.cidade") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "endereco.cidade")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">UF</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.endereco.uf}
+                  onChange={handleAddressChange("uf")}
+                  placeholder="SP"
+                  maxLength={2}
+                />
+                {readError(errors, "endereco.uf") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "endereco.uf")}</span>
+                )}
+              </label>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="text-base font-semibold">Responsável</h3>
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="text-sm">
+                <span className="text-gray-600">Nome</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.responsavel.nome}
+                  onChange={handleResponsavelChange("nome")}
+                />
+                {readError(errors, "responsavel.nome") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "responsavel.nome")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">CPF</span>
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.responsavel.cpf}
+                  onChange={handleResponsavelChange("cpf")}
+                  placeholder="000.000.000-00"
+                />
+                {readError(errors, "responsavel.cpf") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "responsavel.cpf")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">E-mail</span>
+                <input
+                  type="email"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.responsavel.email}
+                  onChange={handleResponsavelChange("email")}
+                />
+                {readError(errors, "responsavel.email") && (
+                  <span className="mt-1 block text-xs text-red-600">{readError(errors, "responsavel.email")}</span>
+                )}
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Telefone (E.164)</span>
+                <input
+                  type="tel"
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.responsavel.phone_e164}
+                  onChange={handleResponsavelChange("phone_e164")}
+                  placeholder="+5511999999999"
+                />
+              </label>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-base font-semibold">WhatsApp (Baileys)</h3>
+              {!canManageBaileys && (
+                <span className="text-xs text-gray-400">Apenas leitura</span>
+              )}
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="mt-1 flex items-center gap-2 text-sm text-gray-600">
+                <input
+                  type="checkbox"
+                  checked={form.whatsapp_baileys_enabled}
+                  onChange={handleCheckboxChange("whatsapp_baileys_enabled")}
+                  disabled={!canManageBaileys}
+                  className="h-4 w-4"
+                />
+                Habilitar WhatsApp (Baileys)
+              </label>
+              <label className="text-sm">
+                <span className="text-gray-600">Modo</span>
+                <select
+                  className="mt-1 w-full rounded border px-3 py-2"
+                  value={form.whatsapp_mode}
+                  onChange={handleInputChange("whatsapp_mode")}
+                  disabled={!canManageBaileys}
+                >
+                  {WHATSAPP_MODES.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="text-sm md:col-span-2">
+                <span className="text-gray-600">Status</span>
                 <input
                   type="text"
                   className="mt-1 w-full rounded border px-3 py-2"
                   value={form.whatsapp_baileys_status}
-                  onChange={handleField("whatsapp_baileys_status")}
+                  onChange={handleInputChange("whatsapp_baileys_status")}
+                  readOnly={!canManageBaileys}
                 />
               </label>
-              <label className="text-sm">
-                <span className="block text-gray-600">Telefone Baileys</span>
-                <input
-                  type="text"
-                  className="mt-1 w-full rounded border px-3 py-2"
-                  value={form.whatsapp_baileys_phone}
-                  onChange={handleField("whatsapp_baileys_phone")}
-                />
-              </label>
+              {form.whatsapp_baileys_enabled && (
+                <label className="text-sm md:col-span-2">
+                  <span className="text-gray-600">Telefone (E.164)</span>
+                  <input
+                    type="tel"
+                    className="mt-1 w-full rounded border px-3 py-2"
+                    value={form.whatsapp_baileys_phone}
+                    onChange={handleInputChange("whatsapp_baileys_phone")}
+                    readOnly={!canManageBaileys}
+                    placeholder="+5511999999999"
+                  />
+                  {readError(errors, "whatsapp_baileys_phone") && (
+                    <span className="mt-1 block text-xs text-red-600">{readError(errors, "whatsapp_baileys_phone")}</span>
+                  )}
+                </label>
+              )}
             </div>
           </section>
 
-          <section>
-            <h3 className="text-lg font-semibold">Meta (JSON)</h3>
-            <textarea
-              rows={5}
-              className="mt-2 w-full rounded border px-3 py-2 font-mono text-sm"
-              value={form.metaText}
-              onChange={handleField("metaText")}
-              placeholder={`{
-  "notes": "..."
-}`}
-            />
-            <p className="mt-1 text-xs text-gray-500">Deixe em branco para manter. Envie um objeto JSON válido.</p>
-          </section>
-
-          <div className="flex justify-end gap-3">
+          <div className="flex justify-end gap-3 pt-4">
             <button
               type="button"
-              onClick={close}
-              className="rounded border px-4 py-2 text-sm text-gray-600 hover:bg-gray-50"
+              onClick={handleClose}
+              className="rounded border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:border-gray-300"
               disabled={saving}
             >
               Cancelar
@@ -518,167 +778,6 @@ export default function AdminOrgEditModal({ open, org, onClose, onSaved }) {
             </button>
           </div>
         </form>
-
-        <div className="border-t px-6 py-5">
-          <h3 className="text-lg font-semibold">Registrar mudança de plano</h3>
-          {historyError && (
-            <div className="mt-2 rounded border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700">{historyError}</div>
-          )}
-          {historyMessage && (
-            <div className="mt-2 rounded border border-emerald-300 bg-emerald-50 px-4 py-2 text-sm text-emerald-700">
-              {historyMessage}
-            </div>
-          )}
-          <div className="mt-3 grid gap-3 md:grid-cols-2">
-            <label className="text-sm">
-              <span className="block text-gray-600">Plano</span>
-              <select
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={historyForm.plan_id || ""}
-                onChange={handleHistoryField("plan_id")}
-              >
-                <option value="">{planMap[form.plan_id] || "— manter atual —"}</option>
-                {plans.map((plan) => (
-                  <option key={plan.id} value={plan.id}>
-                    {plan.name || plan.label || plan.id}
-                  </option>
-                ))}
-                {form.plan_id && !planMap[form.plan_id] && (
-                  <option value={form.plan_id}>{form.plan_id}</option>
-                )}
-              </select>
-            </label>
-            <label className="text-sm">
-              <span className="block text-gray-600">Status do plano</span>
-              <select
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={historyForm.status}
-                onChange={handleHistoryField("status")}
-              >
-                <option value="active">Ativo</option>
-                <option value="canceled">Cancelado</option>
-                <option value="suspended">Suspenso</option>
-                <option value="pending">Pendente</option>
-              </select>
-            </label>
-            <label className="text-sm">
-              <span className="block text-gray-600">Início</span>
-              <input
-                type="datetime-local"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={historyForm.start_at}
-                onChange={handleHistoryField("start_at")}
-              />
-            </label>
-            <label className="text-sm">
-              <span className="block text-gray-600">Término</span>
-              <input
-                type="datetime-local"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={historyForm.end_at}
-                onChange={handleHistoryField("end_at")}
-              />
-            </label>
-            <label className="text-sm">
-              <span className="block text-gray-600">Trial até</span>
-              <input
-                type="date"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={historyForm.trial_ends_at || ""}
-                onChange={handleHistoryField("trial_ends_at")}
-              />
-            </label>
-            <label className="text-sm md:col-span-2">
-              <span className="block text-gray-600">Meta (JSON)</span>
-              <textarea
-                rows={3}
-                className="mt-1 w-full rounded border px-3 py-2 font-mono text-sm"
-                value={historyForm.meta}
-                onChange={handleHistoryField("meta")}
-              />
-            </label>
-          </div>
-          <div className="mt-3 flex justify-end">
-            <button
-              type="button"
-              onClick={submitPlanHistory}
-              className="rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-60"
-              disabled={historySaving}
-            >
-              {historySaving ? "Registrando…" : "Registrar"}
-            </button>
-          </div>
-        </div>
-
-        <div className="border-t px-6 py-5">
-          <h3 className="text-lg font-semibold">Ajustar créditos</h3>
-          {creditsError && (
-            <div className="mt-2 rounded border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700">{creditsError}</div>
-          )}
-          {creditsMessage && (
-            <div className="mt-2 rounded border border-emerald-300 bg-emerald-50 px-4 py-2 text-sm text-emerald-700">
-              {creditsMessage}
-            </div>
-          )}
-          <div className="mt-3 grid gap-3 md:grid-cols-2">
-            <label className="text-sm">
-              <span className="block text-gray-600">feature_code</span>
-              <input
-                type="text"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={creditsForm.feature_code}
-                onChange={handleCreditsField("feature_code")}
-              />
-            </label>
-            <label className="text-sm">
-              <span className="block text-gray-600">Delta</span>
-              <input
-                type="number"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={creditsForm.delta}
-                onChange={handleCreditsField("delta")}
-              />
-            </label>
-            <label className="text-sm">
-              <span className="block text-gray-600">Expira em</span>
-              <input
-                type="datetime-local"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={creditsForm.expires_at}
-                onChange={handleCreditsField("expires_at")}
-              />
-            </label>
-            <label className="text-sm">
-              <span className="block text-gray-600">Origem</span>
-              <input
-                type="text"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={creditsForm.source}
-                onChange={handleCreditsField("source")}
-                placeholder="manual | subscription | refund | promo"
-              />
-            </label>
-            <label className="text-sm md:col-span-2">
-              <span className="block text-gray-600">Meta (JSON)</span>
-              <textarea
-                rows={3}
-                className="mt-1 w-full rounded border px-3 py-2 font-mono text-sm"
-                value={creditsForm.meta}
-                onChange={handleCreditsField("meta")}
-              />
-            </label>
-          </div>
-          <div className="mt-3 flex justify-end">
-            <button
-              type="button"
-              onClick={submitCredits}
-              className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-60"
-              disabled={creditsSaving}
-            >
-              {creditsSaving ? "Aplicando…" : "Aplicar"}
-            </button>
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
+++ b/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
@@ -1,709 +1,161 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   adminListOrgs,
-  adminListPlans,
-  patchAdminOrg,
-  patchAdminOrgCredits,
-  putAdminOrgPlan,
+  deleteAdminOrg,
 } from "@/api/inboxApi";
+import AdminOrgEditModal from "./AdminOrgEditModal.jsx";
 
-function toInputDate(value) {
-  if (!value) return "";
-  try {
-    const d = new Date(value);
-    if (Number.isNaN(d.getTime())) return String(value).slice(0, 10);
-    return d.toISOString().slice(0, 10);
-  } catch {
-    return "";
-  }
-}
-
-const ORG_STATUS_OPTIONS = [
-  { value: "active", label: "Ativa" },
-  { value: "inactive", label: "Inativa" },
-];
-
-const PLAN_STATUS_OPTIONS = [
-  { value: "active", label: "Ativo" },
-  { value: "pending", label: "Pendente" },
-  { value: "suspended", label: "Suspenso" },
-  { value: "canceled", label: "Cancelado" },
-];
-
-function fromInputDate(value) {
-  if (!value) return null;
-  try {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return null;
-    return date.toISOString();
-  } catch {
-    return null;
-  }
-}
-
-function normalizeOrgData(org) {
-  if (!org || typeof org !== "object") return org;
-  const active = typeof org.active === "boolean" ? org.active : org.status === "active";
-  const statusValue =
-    org.status ?? (typeof active === "boolean" ? (active ? "active" : "inactive") : undefined);
-  return { ...org, active, status: statusValue };
-}
-
-function fromInputDateTime(value) {
-  if (!value) return null;
-  try {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return null;
-    return date.toISOString();
-  } catch {
-    return null;
-  }
-}
-
-function EditOrgModal({ org, onClose, onSaved }) {
-  const [basicForm, setBasicForm] = useState({
-    name: "",
-    slug: "",
-    status: "active",
-    email: "",
-    phone: "",
-    trial_ends_at: "",
-  });
-  const [planForm, setPlanForm] = useState({
-    plan_id: "",
-    status: "active",
-    start_at: "",
-    end_at: "",
-    trial_ends_at: "",
-    meta: "",
-  });
-  const [creditsForm, setCreditsForm] = useState({
-    feature_code: "",
-    delta: "",
-    expires_at: "",
-    source: "manual",
-    meta: "",
-  });
-  const [plans, setPlans] = useState([]);
-  const [loadingPlans, setLoadingPlans] = useState(false);
-  const [savingBasic, setSavingBasic] = useState(false);
-  const [savingPlan, setSavingPlan] = useState(false);
-  const [savingCredits, setSavingCredits] = useState(false);
-  const [basicError, setBasicError] = useState("");
-  const [basicSuccess, setBasicSuccess] = useState("");
-  const [planError, setPlanError] = useState("");
-  const [planSuccess, setPlanSuccess] = useState("");
-  const [creditsError, setCreditsError] = useState("");
-  const [creditsSuccess, setCreditsSuccess] = useState("");
-
-  useEffect(() => {
-    if (!org) return;
-    setBasicForm({
-      name: org.name || "",
-      slug: org.slug || "",
-      status: org.status || "active",
-      email: org.email || "",
-      phone: org.phone || "",
-      trial_ends_at: toInputDate(org.trial_ends_at),
-    });
-    setPlanForm((prev) => ({
-      ...prev,
-      plan_id: org.plan_id || "",
-      status: org.status === "inactive" ? "suspended" : "active",
-      trial_ends_at: toInputDate(org.trial_ends_at),
-    }));
-    setCreditsForm((prev) => ({ ...prev, feature_code: "", delta: "", expires_at: "", meta: "" }));
-    setBasicError("");
-    setBasicSuccess("");
-    setPlanError("");
-    setPlanSuccess("");
-    setCreditsError("");
-    setCreditsSuccess("");
-  }, [org]);
-
-  useEffect(() => {
-    if (!org) return;
-    let cancelled = false;
-    setLoadingPlans(true);
-    (async () => {
-      try {
-        const { plans: planList } = await adminListPlans();
-        if (!cancelled) {
-          const list = Array.isArray(planList) ? planList : [];
-          setPlans(list);
-        }
-      } catch {
-        if (!cancelled) setPlans([]);
-      } finally {
-        if (!cancelled) setLoadingPlans(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [org]);
-
-  const planMap = useMemo(() => {
-    return plans.reduce((acc, plan) => {
-      const label = plan?.name || plan?.title || plan?.label || plan?.id || plan?.slug;
-      if (!label) return acc;
-      if (plan?.id) acc[plan.id] = label;
-      if (plan?.slug) acc[plan.slug] = label;
-      if (plan?.id_legacy_text) acc[plan.id_legacy_text] = label;
-      return acc;
-    }, {});
-  }, [plans]);
-
-  if (!org) return null;
-
-  const close = () => {
-    if (savingBasic || savingPlan || savingCredits) return;
-    onClose?.();
-  };
-
-  const handleBasicChange = (field) => (event) => {
-    const value = event?.target?.value ?? "";
-    setBasicForm((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const handlePlanChange = (field) => (event) => {
-    const value = event?.target?.value ?? "";
-    setPlanForm((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const handleCreditsChange = (field) => (event) => {
-    const value = event?.target?.value ?? "";
-    setCreditsForm((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const submitBasic = async (event) => {
-    event?.preventDefault();
-    if (savingBasic) return;
-    setBasicError("");
-    setBasicSuccess("");
-    setSavingBasic(true);
-    try {
-      const payload = {
-        name: basicForm.name?.trim() || org.name || "",
-        slug: basicForm.slug?.trim() || null,
-        status: basicForm.status || "active",
-        email: basicForm.email?.trim() || null,
-        phone: basicForm.phone?.trim() || null,
-        trial_ends_at: fromInputDate(basicForm.trial_ends_at),
-      };
-      const response = await patchAdminOrg(org.id, payload);
-      const data = response?.data;
-      const merged = {
-        ...org,
-        ...(data?.org || {}),
-        ...(Array.isArray(data?.data) ? {} : data?.data || {}),
-        ...(!data?.org && !data?.data ? data || {} : {}),
-        ...payload,
-      };
-      onSaved?.({ ...org, ...merged });
-      setBasicSuccess("Dados atualizados com sucesso.");
-    } catch (e) {
-      const message = e?.response?.data?.error || e?.message || "Falha ao salvar.";
-      setBasicError(message);
-    } finally {
-      setSavingBasic(false);
-    }
-  };
-
-  const submitPlan = async (event) => {
-    event?.preventDefault();
-    if (savingPlan) return;
-    setPlanError("");
-    setPlanSuccess("");
-    if (!planForm.plan_id) {
-      setPlanError("Selecione um plano.");
-      return;
-    }
-    let parsedMeta;
-    if (planForm.meta) {
-      try {
-        parsedMeta = JSON.parse(planForm.meta);
-      } catch {
-        setPlanError("Meta deve ser um JSON válido.");
-        return;
-      }
-    }
-    setSavingPlan(true);
-    try {
-      const payload = {
-        plan_id: planForm.plan_id,
-        status: planForm.status || "active",
-        start_at: fromInputDateTime(planForm.start_at),
-        end_at: fromInputDateTime(planForm.end_at),
-        trial_ends_at: fromInputDate(planForm.trial_ends_at),
-        meta: parsedMeta,
-      };
-      await putAdminOrgPlan(org.id, payload);
-      onSaved?.({
-        ...org,
-        plan_id: payload.plan_id,
-        plan_name: planMap[payload.plan_id] || org.plan_name || null,
-        trial_ends_at: payload.trial_ends_at ?? org.trial_ends_at ?? null,
-      });
-      setPlanSuccess("Plano atualizado com sucesso.");
-    } catch (e) {
-      const message = e?.response?.data?.error || e?.message || "Não foi possível atualizar o plano.";
-      setPlanError(message);
-    } finally {
-      setSavingPlan(false);
-    }
-  };
-
-  const submitCredits = async (event) => {
-    event?.preventDefault();
-    if (savingCredits) return;
-    setCreditsError("");
-    setCreditsSuccess("");
-    const feature = creditsForm.feature_code?.trim();
-    if (!feature) {
-      setCreditsError("Informe o código da feature.");
-      return;
-    }
-    const deltaNumber = Number(creditsForm.delta);
-    if (!Number.isFinite(deltaNumber)) {
-      setCreditsError("Delta deve ser um número.");
-      return;
-    }
-    let meta;
-    if (creditsForm.meta) {
-      try {
-        meta = JSON.parse(creditsForm.meta);
-      } catch {
-        setCreditsError("Meta deve ser JSON válido.");
-        return;
-      }
-    }
-    setSavingCredits(true);
-    try {
-      const payload = {
-        feature_code: feature,
-        delta: Math.trunc(deltaNumber),
-        expires_at: fromInputDateTime(creditsForm.expires_at),
-        source: creditsForm.source?.trim() || undefined,
-        meta,
-      };
-      await patchAdminOrgCredits(org.id, payload);
-      setCreditsSuccess("Créditos registrados.");
-      setCreditsForm((prev) => ({
-        ...prev,
-        feature_code: "",
-        delta: "",
-        expires_at: "",
-        meta: "",
-      }));
-    } catch (e) {
-      const message = e?.response?.data?.error || e?.message || "Não foi possível registrar créditos.";
-      setCreditsError(message);
-    } finally {
-      setSavingCredits(false);
-    }
-  };
-
+function StatusBadge({ status }) {
+  const active = String(status).toLowerCase() === "active";
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-3xl rounded-lg bg-white p-6 shadow-xl">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-lg font-semibold">Editar organização</h2>
-            <p className="mt-1 text-sm text-gray-500">{org.name}</p>
-          </div>
-          <button
-            type="button"
-            className="text-sm text-gray-500 hover:text-gray-800"
-            onClick={close}
-            disabled={savingBasic || savingPlan || savingCredits}
-          >
-            Fechar
-          </button>
-        </div>
-
-        <div className="mt-4 grid gap-6 md:grid-cols-2">
-          <form
-            onSubmit={submitBasic}
-            className="space-y-3"
-            data-testid="admin-org-basic-form"
-          >
-            <h3 className="font-medium">Dados básicos</h3>
-            {basicError && (
-              <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
-                {basicError}
-              </div>
-            )}
-            {basicSuccess && (
-              <div className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
-                {basicSuccess}
-              </div>
-            )}
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Nome
-              <input
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={basicForm.name}
-                onChange={handleBasicChange("name")}
-                disabled={savingBasic}
-                data-testid="admin-org-basic-name"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Slug
-              <input
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={basicForm.slug}
-                onChange={handleBasicChange("slug")}
-                disabled={savingBasic}
-                data-testid="admin-org-basic-slug"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              E-mail
-              <input
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={basicForm.email}
-                onChange={handleBasicChange("email")}
-                disabled={savingBasic}
-                data-testid="admin-org-basic-email"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Telefone
-              <input
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={basicForm.phone}
-                onChange={handleBasicChange("phone")}
-                disabled={savingBasic}
-                data-testid="admin-org-basic-phone"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Status
-              <select
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={basicForm.status}
-                onChange={handleBasicChange("status")}
-                disabled={savingBasic}
-              >
-                {ORG_STATUS_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Trial até
-              <input
-                type="date"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={basicForm.trial_ends_at || ""}
-                onChange={handleBasicChange("trial_ends_at")}
-                disabled={savingBasic}
-              />
-            </label>
-            <div className="flex justify-end pt-2">
-              <button
-                type="submit"
-                className="rounded bg-blue-600 px-4 py-2 text-sm text-white disabled:opacity-60"
-                disabled={savingBasic}
-                data-testid="admin-org-basic-save"
-              >
-                {savingBasic ? "Salvando…" : "Salvar"}
-              </button>
-            </div>
-          </form>
-
-          <form
-            onSubmit={submitPlan}
-            className="space-y-3"
-            data-testid="admin-org-plan-form"
-          >
-            <h3 className="font-medium">Plano</h3>
-            {planError && (
-              <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
-                {planError}
-              </div>
-            )}
-            {planSuccess && (
-              <div className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
-                {planSuccess}
-              </div>
-            )}
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Plano
-              <select
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={planForm.plan_id}
-                onChange={handlePlanChange("plan_id")}
-                disabled={loadingPlans || savingPlan}
-                data-testid="admin-org-plan-select"
-              >
-                <option value="">—</option>
-                {plans.map((plan) => {
-                  const value = plan.id || plan.slug || plan.id_legacy_text || "";
-                  const label = plan.name || plan.title || plan.label || value;
-                  return (
-                    <option key={value || plan.name} value={value}>
-                      {label}
-                    </option>
-                  );
-                })}
-              </select>
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Status do histórico
-              <select
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={planForm.status}
-                onChange={handlePlanChange("status")}
-                disabled={savingPlan}
-                data-testid="admin-org-plan-status"
-              >
-                {PLAN_STATUS_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Trial até
-              <input
-                type="date"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={planForm.trial_ends_at || ""}
-                onChange={handlePlanChange("trial_ends_at")}
-                disabled={savingPlan}
-                data-testid="admin-org-plan-trial"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Início
-              <input
-                type="datetime-local"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={planForm.start_at}
-                onChange={handlePlanChange("start_at")}
-                disabled={savingPlan}
-                data-testid="admin-org-plan-start"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Encerramento
-              <input
-                type="datetime-local"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={planForm.end_at}
-                onChange={handlePlanChange("end_at")}
-                disabled={savingPlan}
-                data-testid="admin-org-plan-end"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Meta (JSON opcional)
-              <textarea
-                className="mt-1 h-24 w-full rounded border px-3 py-2 text-sm"
-                value={planForm.meta}
-                onChange={handlePlanChange("meta")}
-                disabled={savingPlan}
-                data-testid="admin-org-plan-meta"
-              />
-            </label>
-            <div className="flex justify-end pt-2">
-              <button
-                type="submit"
-                className="rounded bg-indigo-600 px-4 py-2 text-sm text-white disabled:opacity-60"
-                disabled={savingPlan}
-                data-testid="admin-org-plan-save"
-              >
-                {savingPlan ? "Registrando…" : "Registrar plano"}
-              </button>
-            </div>
-          </form>
-        </div>
-
-        <form
-          onSubmit={submitCredits}
-          className="mt-6 space-y-3"
-          data-testid="admin-org-credits-form"
-        >
-          <h3 className="font-medium">Créditos</h3>
-          <p className="text-xs text-gray-500">
-            Ajuste manual de créditos para recursos específicos da organização.
-          </p>
-          {creditsError && (
-            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
-              {creditsError}
-            </div>
-          )}
-          {creditsSuccess && (
-            <div className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
-              {creditsSuccess}
-            </div>
-          )}
-          <div className="grid gap-3 md:grid-cols-2">
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Feature
-              <input
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={creditsForm.feature_code}
-                onChange={handleCreditsChange("feature_code")}
-                disabled={savingCredits}
-                data-testid="admin-org-credits-feature"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Delta
-              <input
-                type="number"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={creditsForm.delta}
-                onChange={handleCreditsChange("delta")}
-                disabled={savingCredits}
-                data-testid="admin-org-credits-delta"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Expira em
-              <input
-                type="datetime-local"
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={creditsForm.expires_at}
-                onChange={handleCreditsChange("expires_at")}
-                disabled={savingCredits}
-                data-testid="admin-org-credits-expires"
-              />
-            </label>
-            <label className="block text-xs uppercase tracking-wide text-gray-500">
-              Fonte
-              <input
-                className="mt-1 w-full rounded border px-3 py-2"
-                value={creditsForm.source}
-                onChange={handleCreditsChange("source")}
-                disabled={savingCredits}
-                data-testid="admin-org-credits-source"
-              />
-            </label>
-          </div>
-          <label className="block text-xs uppercase tracking-wide text-gray-500">
-            Meta (JSON opcional)
-            <textarea
-              className="mt-1 h-24 w-full rounded border px-3 py-2 text-sm"
-              value={creditsForm.meta}
-              onChange={handleCreditsChange("meta")}
-              disabled={savingCredits}
-              data-testid="admin-org-credits-meta"
-            />
-          </label>
-          <div className="flex justify-end">
-            <button
-              type="submit"
-              className="rounded bg-emerald-600 px-4 py-2 text-sm text-white disabled:opacity-60"
-              disabled={savingCredits}
-              data-testid="admin-org-credits-save"
-            >
-              {savingCredits ? "Registrando…" : "Aplicar créditos"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+    <span className="inline-flex items-center gap-2">
+      <span
+        className={`inline-block h-2.5 w-2.5 rounded-full ${active ? "bg-green-500" : "bg-gray-300"}`}
+        aria-hidden="true"
+      />
+      {active ? "Ativa" : "Inativa"}
+    </span>
   );
+}
+
+const STATUS_FILTERS = [
+  { value: "active", label: "Ativas" },
+  { value: "inactive", label: "Inativas" },
+  { value: "all", label: "Todas" },
+];
+
+function formatDate(value) {
+  if (!value) return "—";
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "—";
+    return new Intl.DateTimeFormat("pt-BR").format(date);
+  } catch {
+    return "—";
+  }
+}
+
+function normalizeOrg(org) {
+  if (!org || typeof org !== "object") return null;
+  const status = org.status
+    ? String(org.status).toLowerCase()
+    : typeof org.active === "boolean"
+    ? org.active
+      ? "active"
+      : "inactive"
+    : "inactive";
+  return {
+    ...org,
+    status,
+    active: status === "active",
+  };
 }
 
 export default function AdminOrganizationsPage() {
+  const [items, setItems] = useState([]);
   const [status, setStatus] = useState("active");
   const [searchInput, setSearchInput] = useState("");
   const [query, setQuery] = useState("");
-  const [items, setItems] = useState([]);
-  const [editingOrg, setEditingOrg] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [modalMode, setModalMode] = useState(null);
+  const [selectedOrg, setSelectedOrg] = useState(null);
 
-  const load = useCallback(
-    async (overrides = {}) => {
-      const currentStatus = overrides.status ?? status;
-      const currentQuery = overrides.q ?? query;
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await adminListOrgs({ status: currentStatus, q: currentQuery });
-        const list = Array.isArray(data) ? data.map(normalizeOrgData) : [];
-        setItems(list);
-      } catch (err) {
-        const statusCode = err?.response?.status;
-        if (!statusCode || statusCode >= 400) {
-          setError("Não foi possível carregar as organizações.");
-        }
-      } finally {
-        setLoading(false);
-      }
-    },
-    [query, status],
-  );
+  const fetchOrgs = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const data = await adminListOrgs({ status, q: query });
+      const list = Array.isArray(data) ? data : [];
+      setItems(list.map((org) => normalizeOrg(org)).filter(Boolean));
+    } catch (err) {
+      const message = err?.response?.data?.error || err?.message || "Falha ao carregar organizações.";
+      setError(message);
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [status, query]);
 
   useEffect(() => {
-    load();
-  }, [load]);
+    fetchOrgs();
+  }, [fetchOrgs]);
 
-  const handleStatusChange = useCallback(
-    (nextStatus) => {
-      setStatus((prev) => {
-        if (prev === nextStatus) {
-          load({ status: nextStatus });
-          return prev;
-        }
-        return nextStatus;
-      });
-    },
-    [load],
-  );
-
-  const handleSearch = useCallback(() => {
-    const nextQuery = searchInput.trim();
-    setQuery((prev) => {
-      if (prev === nextQuery) {
-        load({ q: nextQuery });
-        return prev;
-      }
-      return nextQuery;
-    });
-  }, [load, searchInput]);
-
-  const handleSearchKeyDown = useCallback(
-    (event) => {
-      if (event.key === "Enter") {
-        event.preventDefault();
-        handleSearch();
-      }
-    },
-    [handleSearch],
-  );
-
-  const handleSaved = (updatedOrg) => {
-    if (!updatedOrg?.id) return;
-    setItems((prev) =>
-      prev.map((org) => (org.id === updatedOrg.id ? { ...org, ...normalizeOrgData(updatedOrg) } : org))
-    );
-    setEditingOrg(null);
+  const handleStatusChange = (value) => {
+    setStatus(value);
   };
 
+  const handleSearch = useCallback(() => {
+    setQuery(searchInput.trim());
+  }, [searchInput]);
+
+  const handleSearchKeyDown = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleSearch();
+    }
+  };
+
+  const openCreate = () => {
+    setSelectedOrg(null);
+    setModalMode("create");
+  };
+
+  const openEdit = (org) => {
+    setSelectedOrg(org);
+    setModalMode("edit");
+  };
+
+  const closeModal = () => {
+    setSelectedOrg(null);
+    setModalMode(null);
+  };
+
+  const handleSaved = () => {
+    closeModal();
+    fetchOrgs();
+  };
+
+  const handleDelete = async (org) => {
+    if (!org) return;
+    const confirmed = window.confirm(`Deseja excluir a organização "${org.name}"?`);
+    if (!confirmed) return;
+    try {
+      await deleteAdminOrg(org.id);
+      fetchOrgs();
+    } catch (err) {
+      const message = err?.response?.data?.error || err?.message || "Falha ao excluir organização.";
+      setError(message);
+    }
+  };
+
+  const showModal = modalMode === "create" || modalMode === "edit";
+
+  const tableItems = useMemo(() => items, [items]);
+
   return (
-    <div className="p-4">
-      <div className="mb-4 flex flex-wrap gap-2">
-        {[
-          { value: "active", label: "Ativas" },
-          { value: "inactive", label: "Inativas" },
-          { value: "all", label: "Todas" },
-        ].map((option) => (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Organizações</h1>
+          <p className="text-sm text-gray-500">Gerencie empresas, status e configurações gerais.</p>
+        </div>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="inline-flex items-center rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
+        >
+          + Nova organização
+        </button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        {STATUS_FILTERS.map((option) => (
           <button
             key={option.value}
             type="button"
             onClick={() => handleStatusChange(option.value)}
-            className={`rounded-full border px-4 py-1 text-sm ${
+            className={`rounded-full border px-4 py-1 text-sm transition ${
               status === option.value
                 ? "border-blue-600 bg-blue-50 text-blue-700"
                 : "border-gray-200 text-gray-600 hover:border-blue-200"
@@ -712,74 +164,92 @@ export default function AdminOrganizationsPage() {
             {option.label}
           </button>
         ))}
-        <div className="ml-auto flex gap-2">
+        <div className="ml-auto flex w-full gap-2 sm:w-auto">
           <input
             value={searchInput}
             onChange={(event) => setSearchInput(event.target.value)}
             onKeyDown={handleSearchKeyDown}
             placeholder="Buscar por nome…"
-            className="input input-bordered"
+            className="flex-1 rounded border px-3 py-2 text-sm"
             type="search"
           />
-          <button type="button" onClick={handleSearch} className="btn">
+          <button
+            type="button"
+            onClick={handleSearch}
+            className="rounded border border-gray-200 px-4 py-2 text-sm text-gray-700 transition hover:border-blue-200 hover:text-blue-700"
+          >
             Buscar
           </button>
         </div>
       </div>
-      {loading && (
-        <div className="mb-4 text-sm text-gray-500">Carregando…</div>
-      )}
+
+      {loading && <div className="text-sm text-gray-500">Carregando…</div>}
       {!loading && error && (
-        <div className="mb-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-          {error}
-        </div>
+        <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>
       )}
-      {!loading && !error && items.length === 0 && (
-        <div className="text-sm text-gray-500">Nenhuma organização.</div>
-      )}
-      {!loading && !error && items.length > 0 && (
-        <table className="w-full">
-          <thead>
-            <tr>
-              <th>Nome</th>
-              <th>Plano</th>
-              <th>Trial</th>
-              <th>Status</th>
-              <th>Ações</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((org) => (
-              <tr key={org.id}>
-                <td>
-                  <div className="font-medium">{org.name}</div>
-                  <div className="text-xs text-gray-500">{org.slug}</div>
-                </td>
-                <td>{org.plan_name ?? org.plan_id ?? "—"}</td>
-                <td>{org.trial_ends_at ? new Date(org.trial_ends_at).toLocaleDateString() : "—"}</td>
-                <td>{org.active ? "Ativa" : "Inativa"}</td>
-                <td>
-                  <button
-                    type="button"
-                    className="text-blue-600"
-                    onClick={() => setEditingOrg(org)}
-                  >
-                    Editar
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      {!loading && !error && tableItems.length === 0 && (
+        <div className="text-sm text-gray-500">Nenhuma organização encontrada.</div>
       )}
 
-      {editingOrg && (
-        <EditOrgModal
-          org={editingOrg}
-          onClose={() => setEditingOrg(null)}
-          onSaved={handleSaved}
-        />
+      {!loading && !error && tableItems.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border border-gray-200">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-4 py-3">Nome</th>
+                <th className="px-4 py-3">Plano</th>
+                <th className="px-4 py-3">Trial</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3 text-right">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white">
+              {tableItems.map((org) => (
+                <tr key={org.id}>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-gray-900">{org.name || org.razao_social || "—"}</div>
+                    <div className="text-xs text-gray-500">{org.slug || org.cnpj || ""}</div>
+                  </td>
+                  <td className="px-4 py-3">{org.plan_name ?? org.plan ?? org.plan_id ?? "—"}</td>
+                  <td className="px-4 py-3">{formatDate(org.trial_ends_at)}</td>
+                  <td className="px-4 py-3">
+                    <StatusBadge status={org.status} />
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="inline-flex items-center gap-3">
+                      <button
+                        type="button"
+                        className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                        onClick={() => openEdit(org)}
+                      >
+                        Editar
+                      </button>
+                      <button
+                        type="button"
+                        className="text-sm font-medium text-red-600 hover:text-red-800"
+                        onClick={() => handleDelete(org)}
+                        aria-label={`Excluir ${org.name}`}
+                      >
+                        Excluir
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
+
+      <AdminOrgEditModal
+        open={showModal}
+        mode={modalMode}
+        org={modalMode === "edit" ? selectedOrg : null}
+        onClose={closeModal}
+        onSaved={handleSaved}
+      />
     </div>
   );
 }
+
+export { StatusBadge };


### PR DESCRIPTION
## Summary
- add BrasilAPI-backed CNPJ/CEP lookup service and expose the endpoints under `/api/utils`
- extend the admin organization patch logic for WhatsApp-only fields and richer company/contact metadata
- refresh the workspace switcher, admin organizations list, and editing modal with auto-fill, validation, and deletion UX

## Testing
- `npm run test:backend --silent` *(fails: environment lacks required dev dependencies such as supertest/pg)*
- `npm run test:frontend --silent` *(fails: legacy test suite expects previous UI and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68db2d2b67388327ac49c6bc7e186ffb