### PR TITLE
Add plan credits routing and organization constraints

### DIFF
--- a/backend/db/migrations/20250930_organizations_indexes.sql
+++ b/backend/db/migrations/20250930_organizations_indexes.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+-- Ensure organizations.slug remains unique
+CREATE UNIQUE INDEX IF NOT EXISTS organizations_slug_key
+  ON public.organizations (slug);
+
+-- Support filtering by status and ordering by creation date
+CREATE INDEX IF NOT EXISTS organizations_status_created_idx
+  ON public.organizations (status, created_at DESC);
+
+-- Add digit-only constraints for CEP and CNPJ when present
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'organizations_cep_digits_chk'
+  ) THEN
+    ALTER TABLE public.organizations
+      ADD CONSTRAINT organizations_cep_digits_chk
+        CHECK (cep IS NULL OR cep ~ '^[0-9]{8}$');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'organizations_cnpj_digits_chk'
+  ) THEN
+    ALTER TABLE public.organizations
+      ADD CONSTRAINT organizations_cnpj_digits_chk
+        CHECK (cnpj IS NULL OR cnpj ~ '^[0-9]{14}$');
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/backend/server.js
+++ b/backend/server.js
@@ -86,6 +86,7 @@ import adminOrgsRouter from './routes/admin/orgs.js';
 import adminOrgByIdRouter from './routes/admin/orgById.js';
 import plansRouter from './routes/plans.js';
 import adminPlansRouter from './routes/admin/plans.js';
+import utilsRouter from './routes/utils.js';
 import calendarCompatRouter from './routes/calendar.compat.js';
 import calendarRemindersRouter from './routes/calendar.reminders.js';
 import createCalendarRemindersOneRouter from './routes/calendar.reminders.one.js';
@@ -267,7 +268,13 @@ function configureApp() {
   app.use('/api/admin', ...adminAuthStack);
 
   // Rotas administrativas de planos (SuperAdmin/Support)
-  app.use('/api/admin/plans', adminPlansRouter);
+  app.use(
+    '/api/admin/plans',
+    authRequired,
+    requireRole(ROLES.SuperAdmin, ROLES.Support),
+    adminContext,
+    adminPlansRouter,
+  );
 
   // Rotas administrativas de organizações
   app.use('/api/admin/orgs', adminOrgsRouter);
@@ -276,6 +283,8 @@ function configureApp() {
 
   // Rotas protegidas exigem auth + guardas de impersonação e contexto RLS
   app.use('/api', authRequired, impersonationGuard, pgRlsContext);
+
+  app.use('/api/utils', utilsRouter);
 
   // Rotas que são factories e precisam de dependências
   const calendarRemindersOneRoute = createCalendarRemindersOneRouter({


### PR DESCRIPTION
## Summary
- ensure the admin plans router is mounted with the required auth stack and expose the nested credits endpoints
- expose the /api/utils router and add database indexes and constraints for organizations slug, status ordering, CEP and CNPJ digits

## Testing
- npm run db:migrate *(fails: Missing script "db:migrate")*

------
https://chatgpt.com/codex/tasks/task_e_68dbdb55c1708327a94aeb68de730f73