### PR TITLE
Clean up plan credits when deleting a plan

### DIFF
--- a/backend/routes/admin.plans.js
+++ b/backend/routes/admin.plans.js
@@ -153,6 +153,7 @@ router.delete("/:id", async (req, res, next) => {
     if (!id) return res.status(400).json({ error: "missing_id" });
     await query('DELETE FROM public.plans WHERE id=$1', [id]);
     await query('DELETE FROM public.plans_meta WHERE plan_id=$1', [id]);
+    await query('DELETE FROM public.plan_credits WHERE plan_id=$1', [id]);
     res.json({ ok: true });
   } catch (e) {
     next(e);


### PR DESCRIPTION
## Summary
- remove plan-specific credit rows when a plan is deleted through the admin API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe314404c8327aa5212b948e76c25