### PR TITLE
Add Brazil utility lookups and plan credit helpers

### DIFF
--- a/backend/migrations/2025-09-29_organizations_and_plan_credits.sql
+++ b/backend/migrations/2025-09-29_organizations_and_plan_credits.sql
@@ -38,6 +38,13 @@ ALTER TABLE public.plans
   ADD COLUMN IF NOT EXISTS code text UNIQUE,
   ADD COLUMN IF NOT EXISTS ai_tokens_limit bigint NOT NULL DEFAULT 0;
 
+CREATE TABLE IF NOT EXISTS public.org_members (
+  org_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  role text,
+  PRIMARY KEY (org_id, user_id)
+);
+
 -- seeds coerentes com plan_id das suas orgs
 INSERT INTO public.plans (id, name, code)
 VALUES

--- a/backend/routes/utils.js
+++ b/backend/routes/utils.js
@@ -6,19 +6,17 @@ const router = Router();
 
 router.get('/cnpj/:cnpj', authRequired, async (req, res) => {
   try {
-    const data = await lookupCNPJ(req.params.cnpj);
-    return res.json(data);
+    res.json(await lookupCNPJ(req.params.cnpj));
   } catch (e) {
-    return res.status(422).json({ error: e.message });
+    res.status(422).json({ error: e.message });
   }
 });
 
 router.get('/cep/:cep', authRequired, async (req, res) => {
   try {
-    const data = await lookupCEP(req.params.cep);
-    return res.json(data);
+    res.json(await lookupCEP(req.params.cep));
   } catch (e) {
-    return res.status(422).json({ error: e.message });
+    res.status(422).json({ error: e.message });
   }
 });
 

--- a/frontend/src/api/inboxApi.js
+++ b/frontend/src/api/inboxApi.js
@@ -385,13 +385,25 @@ export async function switchOrg(orgId) {
 }
 
 export async function lookupCNPJ(cnpj) {
-  const { data } = await api.get(`/utils/cnpj/${encodeURIComponent(cnpj)}`);
+  const config = withGlobalScope();
+  const { data } = await api.get(`/utils/cnpj/${encodeURIComponent(cnpj)}`, config);
   return data;
 }
 
 export async function lookupCEP(cep) {
-  const { data } = await api.get(`/utils/cep/${encodeURIComponent(cep)}`);
+  const config = withGlobalScope();
+  const { data } = await api.get(`/utils/cep/${encodeURIComponent(cep)}`, config);
   return data;
+}
+
+export async function getPlanCredits(planId) {
+  const { data } = await api.get(`/admin/plans/${planId}/credits`, withGlobalScope());
+  return data?.data ?? [];
+}
+
+export async function setPlanCredits(planId, payload /* {data:[{meter,limit}]} */) {
+  const { data } = await api.put(`/admin/plans/${planId}/credits`, payload, withGlobalScope());
+  return data?.data ?? [];
 }
 
 export async function putAdminOrgPlan(orgId, payload, options = {}) {


### PR DESCRIPTION
## Summary
- expose authenticated CEP and CNPJ lookup endpoints backed by BrasilAPI
- ensure org_members table exists alongside plan credits migration
- add frontend helpers for Brasil lookups and plan credit management

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc37b1018483279a6fe5c716f332b4