### PR TITLE
Adjust org listing for admins and refresh admin org table

### DIFF
--- a/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
+++ b/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
@@ -23,13 +23,12 @@ function normalizeOrgData(org) {
     };
   }
   const status = String(org.status ?? '').toLowerCase();
-  const planName = org.plan ?? org.plan_name ?? null;
   return {
     id: org.id ?? null,
     name: org.name ?? org.razao_social ?? 'Sem nome',
     slug: org.slug ?? '',
     status: status || 'inactive',
-    plan: planName,
+    plan: org.plan ?? null,
     raw: org,
   };
 }


### PR DESCRIPTION
## Summary
- ensure the `/api/orgs/me` handler returns every organization for global admins and member-only listings for regular users
- rely on the backend-provided `plan` field in the admin organizations table so the displayed plan names stay in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4db73f2083278422cc04a53f1603