### PR TITLE
Normalize CEP/CNPJ utils and streamline org administration

### DIFF
--- a/backend/routes/utils.js
+++ b/backend/routes/utils.js
@@ -4,23 +4,33 @@ import { lookupCNPJ, lookupCEP } from '../services/brasilapi.js';
 
 const router = express.Router();
 
+const onlyDigits = (s = '') => s.replace(/\D+/g, '');
+
 router.get('/cnpj/:cnpj', authRequired, async (req, res) => {
-  const raw = (req.params.cnpj || '').replace(/\D+/g, '');
-  if (raw.length !== 14) return res.status(422).json({ error: 'invalid_cnpj' });
+  const raw = onlyDigits(req.params.cnpj);
+  if (raw.length !== 14) return res.status(422).json({ error: 'invalid cnpj' });
   try {
     res.json(await lookupCNPJ(raw));
   } catch (e) {
-    res.status(422).json({ error: e?.message || 'lookup_failed' });
+    const err = String(e?.message || '').toLowerCase();
+    if (err === 'invalid_cnpj') {
+      return res.status(422).json({ error: 'invalid cnpj' });
+    }
+    return res.status(422).json({ error: err || 'lookup_failed' });
   }
 });
 
 router.get('/cep/:cep', authRequired, async (req, res) => {
-  const raw = (req.params.cep || '').replace(/\D+/g, '');
-  if (raw.length !== 8) return res.status(422).json({ error: 'invalid_cep' });
+  const raw = onlyDigits(req.params.cep);
+  if (raw.length !== 8) return res.status(422).json({ error: 'invalid cep' });
   try {
     res.json(await lookupCEP(raw));
   } catch (e) {
-    res.status(422).json({ error: e?.message || 'lookup_failed' });
+    const err = String(e?.message || '').toLowerCase();
+    if (err === 'invalid_cep') {
+      return res.status(422).json({ error: 'invalid cep' });
+    }
+    return res.status(422).json({ error: err || 'lookup_failed' });
   }
 });
 

--- a/frontend/src/api/inboxApi.js
+++ b/frontend/src/api/inboxApi.js
@@ -375,6 +375,12 @@ export async function deleteAdminOrg(id) {
   await api.delete(`/admin/orgs/${id}`, withGlobalScope());
 }
 
+export async function getCurrentOrg(options = {}) {
+  const config = withGlobalScope(options);
+  const { data } = await api.get('/orgs/current', config);
+  return data;
+}
+
 export async function getMyOrgs() {
   const { data } = await api.get('/orgs/me');
   return data;

--- a/frontend/src/pages/admin/organizations/AdminOrgEditModal.jsx
+++ b/frontend/src/pages/admin/organizations/AdminOrgEditModal.jsx
@@ -185,7 +185,7 @@ export default function AdminOrgEditModal({ open, mode = "edit", org, onClose, o
   };
 
   const handleCheckboxChange = (field) => (event) => {
-    setField(field, event.target.checked);
+    setField(field, !!event.target.checked);
   };
 
   const handleAddressChange = (field) => (event) => {
@@ -336,9 +336,13 @@ export default function AdminOrgEditModal({ open, mode = "edit", org, onClose, o
       applyCnpjData(data);
       setFeedback("Dados do CNPJ preenchidos automaticamente.");
     } catch (err) {
-      const code = err?.response?.data?.error || "lookup_failed";
-      const message = code === "invalid_cnpj" ? "CNPJ inválido" : "Não foi possível consultar CNPJ";
-      setFieldError("cnpj", message);
+      const raw = err?.response?.data?.error;
+      const normalized = typeof raw === "string" ? raw.toLowerCase().replace(/_/g, " ") : "";
+      if (normalized === "invalid cnpj") {
+        setFieldError("cnpj", "CNPJ inválido");
+      } else {
+        setFieldError("cnpj", "Não foi possível consultar CNPJ");
+      }
     } finally {
       setCnpjLookupLoading(false);
     }
@@ -361,9 +365,13 @@ export default function AdminOrgEditModal({ open, mode = "edit", org, onClose, o
       const data = await lookupCEP(digits);
       applyCepData(data);
     } catch (err) {
-      const code = err?.response?.data?.error || "lookup_failed";
-      const message = code === "invalid_cep" ? "CEP inválido" : "Não foi possível consultar CEP";
-      setFieldError("endereco.cep", message);
+      const raw = err?.response?.data?.error;
+      const normalized = typeof raw === "string" ? raw.toLowerCase().replace(/_/g, " ") : "";
+      if (normalized === "invalid cep") {
+        setFieldError("endereco.cep", "CEP inválido");
+      } else {
+        setFieldError("endereco.cep", "Não foi possível consultar CEP");
+      }
     } finally {
       setCepLookupLoading(false);
     }
@@ -557,7 +565,10 @@ export default function AdminOrgEditModal({ open, mode = "edit", org, onClose, o
             Fechar
           </button>
         </div>
-        <div className="modal-body max-h-[80vh] overflow-y-auto pr-2">
+        <div
+          className="modal-body overflow-y-auto pr-2"
+          style={{ maxHeight: "calc(100vh - 200px)" }}
+        >
           <form onSubmit={handleSubmit} className="space-y-6 px-6 py-5">
           {globalError && (
             <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{globalError}</div>

--- a/frontend/src/ui/layout/Sidebar.jsx
+++ b/frontend/src/ui/layout/Sidebar.jsx
@@ -25,7 +25,6 @@ import {
   hasGlobalRole,
   hasOrgRole,
 } from "../../auth/roles";
-import inboxApi from "../../api/inboxApi.js";
 import { canUse, limitKeyFor } from "../../utils/featureGate.js";
 
 const LS_KEY = "sidebarCollapsed";
@@ -167,19 +166,10 @@ function OrgPicker({ collapsed }) {
 
 export default function Sidebar() {
   const { user, logout } = useAuth();
-  const { selected, publicMode } = useOrg();
+  const { selected, publicMode, org } = useOrg();
   const needsOrg = !publicMode && !selected;
-  const [org, setOrg] = useState(null);
   const canManageOrgAI = hasOrgRole(["OrgAdmin", "OrgOwner"], user) || hasGlobalRole(["SuperAdmin"], user);
   const isSuperAdmin = hasGlobalRole(["SuperAdmin"], user);
-
-  useEffect(() => {
-    if (!selected) {
-      setOrg(null);
-      return;
-    }
-    inboxApi.get('/orgs/current', { meta: { scope: 'global' } }).then((r) => setOrg(r.data)).catch(() => {});
-  }, [selected]);
 
   const [collapsed, setCollapsed] = useState(() => {
     try {


### PR DESCRIPTION
## Summary
- sanitize CEP and CNPJ lookups to strip non-digits and standardize 422 responses
- expose the current organization through OrgContext and reuse it in the sidebar and API helpers
- harden admin organization flows with inline CEP/CNPJ validation and debounced list filtering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc882b52a883278322b581a1e8633b