### PR TITLE
feat: expose integration events and viewer

### DIFF
--- a/backend/db/migrations/20251015_integration_events.sql
+++ b/backend/db/migrations/20251015_integration_events.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.integration_events (
+  id bigserial PRIMARY KEY,
+  org_id uuid NOT NULL,
+  provider text NOT NULL,
+  event_type text,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  received_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.integration_events
+  ALTER COLUMN payload SET DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.integration_events
+  ALTER COLUMN received_at SET DEFAULT now();
+
+ALTER TABLE public.integration_events
+  ADD COLUMN IF NOT EXISTS event_type text;
+
+CREATE INDEX IF NOT EXISTS integration_events_org_provider_received_idx
+  ON public.integration_events (org_id, provider, received_at DESC);
+
+CREATE INDEX IF NOT EXISTS integration_events_received_idx
+  ON public.integration_events (received_at DESC);
+
+COMMIT;

--- a/backend/routes/integrations.events.js
+++ b/backend/routes/integrations.events.js
@@ -1,0 +1,251 @@
+import { Router } from 'express';
+import { pool } from '#db';
+
+const SENSITIVE_KEY_PATTERN = /(token|secret|key|credential|password|signature|bearer|auth)/i;
+const REDACTED_VALUE = '[REDACTED]';
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseJsonLike(value) {
+  if (value === null || value === undefined) return {};
+  if (isPlainObject(value) || Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return isPlainObject(parsed) || Array.isArray(parsed) ? parsed : { value: parsed };
+    } catch {
+      return { value };
+    }
+  }
+  return value;
+}
+
+function sanitizeValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item));
+  }
+  if (isPlainObject(value)) {
+    return Object.entries(value).reduce((acc, [key, current]) => {
+      if (SENSITIVE_KEY_PATTERN.test(key)) {
+        acc[key] = REDACTED_VALUE;
+        return acc;
+      }
+      acc[key] = sanitizeValue(current);
+      return acc;
+    }, {});
+  }
+  return value;
+}
+
+function sanitizePayload(rawPayload) {
+  const parsed = parseJsonLike(rawPayload);
+  const sanitized = sanitizeValue(parsed);
+  return sanitized;
+}
+
+function deriveEventType(explicit, payload) {
+  if (explicit && typeof explicit === 'string' && explicit.trim()) {
+    return explicit;
+  }
+  const source = isPlainObject(payload) ? payload : {};
+  const candidates = [
+    source.event_type,
+    source.type,
+    source.status,
+    source.action,
+    source.object,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate;
+    }
+  }
+  const entryList = Array.isArray(source.entry) ? source.entry : [];
+  for (const entry of entryList) {
+    const changes = Array.isArray(entry?.changes) ? entry.changes : [];
+    for (const change of changes) {
+      if (typeof change?.field === 'string' && change.field.trim()) {
+        return change.field;
+      }
+    }
+  }
+  return null;
+}
+
+function pickFirstString(value) {
+  if (!value) return null;
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = pickFirstString(item);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (isPlainObject(value)) {
+    const priorityKeys = ['summary', 'message', 'description', 'status', 'field'];
+    for (const key of priorityKeys) {
+      if (typeof value[key] === 'string' && value[key].trim()) {
+        return value[key];
+      }
+    }
+    if (value.text && typeof value.text.body === 'string') {
+      return value.text.body;
+    }
+    if (value.messages && Array.isArray(value.messages)) {
+      const fromMessages = pickFirstString(value.messages);
+      if (fromMessages) return fromMessages;
+    }
+    if (value.changes && Array.isArray(value.changes)) {
+      const fromChanges = pickFirstString(value.changes);
+      if (fromChanges) return fromChanges;
+    }
+  }
+  return null;
+}
+
+function deriveSummary(provider, eventType, payload) {
+  const primary = pickFirstString(payload);
+  if (primary && typeof primary === 'string') {
+    const trimmed = primary.trim();
+    if (trimmed) {
+      return trimmed.length > 160 ? `${trimmed.slice(0, 157)}…` : trimmed;
+    }
+  }
+  if (eventType) {
+    return eventType;
+  }
+  if (typeof payload === 'string' && payload.trim()) {
+    const trimmed = payload.trim();
+    return trimmed.length > 160 ? `${trimmed.slice(0, 157)}…` : trimmed;
+  }
+  return `Evento ${provider}`;
+}
+
+function parseLimit(value) {
+  const numeric = Number.parseInt(value, 10);
+  if (Number.isNaN(numeric) || numeric <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(numeric, MAX_LIMIT);
+}
+
+function parseOffset(value) {
+  const numeric = Number.parseInt(value, 10);
+  if (Number.isNaN(numeric) || numeric < 0) {
+    return 0;
+  }
+  return numeric;
+}
+
+function parseDate(value) {
+  if (typeof value !== 'string') return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function sanitizeEventRow(row) {
+  const payload = sanitizePayload(row.payload);
+  const eventType = deriveEventType(row.event_type, payload);
+  const summary = deriveSummary(row.provider, eventType, payload);
+  return {
+    id: row.id,
+    org_id: row.org_id,
+    provider: row.provider,
+    event_type: eventType,
+    received_at: row.received_at instanceof Date ? row.received_at.toISOString() : new Date(row.received_at).toISOString(),
+    summary,
+    payload,
+  };
+}
+
+export function createIntegrationsEventsRouter({ logger = console } = {}) {
+  const router = Router();
+
+  router.use((req, _res, next) => {
+    if (!req.db) {
+      req.db = pool;
+    }
+    if (!req.log) {
+      req.log = logger;
+    }
+    next();
+  });
+
+  router.get('/events', async (req, res) => {
+    const db = req.db || pool;
+    const provider = typeof req.query.provider === 'string' && req.query.provider.trim() ? req.query.provider.trim() : null;
+    const limit = parseLimit(req.query.limit);
+    const offset = parseOffset(req.query.offset);
+    const start = parseDate(req.query.start);
+    const end = parseDate(req.query.end);
+
+    const orgFromQuery = typeof req.query.orgId === 'string' && req.query.orgId.trim() ? req.query.orgId.trim() : null;
+    const orgId = orgFromQuery || req.orgId || req.user?.org_id;
+
+    if (!orgId) {
+      return res.status(400).json({ error: 'org_required', message: 'OrgId obrigatório.' });
+    }
+
+    const conditions = ['org_id = $1'];
+    const params = [orgId];
+
+    if (provider) {
+      params.push(provider);
+      conditions.push(`provider = $${params.length}`);
+    }
+    if (start) {
+      params.push(start.toISOString());
+      conditions.push(`received_at >= $${params.length}`);
+    }
+    if (end) {
+      params.push(end.toISOString());
+      conditions.push(`received_at <= $${params.length}`);
+    }
+
+    const whereClause = conditions.join(' AND ');
+    const limitIndex = params.length + 1;
+    const offsetIndex = params.length + 2;
+
+    try {
+      const countQuery = `SELECT COUNT(*) AS total FROM integration_events WHERE ${whereClause}`;
+      const dataQuery = `
+        SELECT id, org_id, provider, event_type, payload, received_at
+          FROM integration_events
+         WHERE ${whereClause}
+         ORDER BY received_at DESC
+         LIMIT $${limitIndex}
+         OFFSET $${offsetIndex}
+      `;
+
+      const [countResult, rowsResult] = await Promise.all([
+        db.query(countQuery, params),
+        db.query(dataQuery, [...params, limit, offset]),
+      ]);
+
+      const total = Number.parseInt(countResult.rows?.[0]?.total ?? '0', 10) || 0;
+      const items = rowsResult.rows.map((row) => sanitizeEventRow(row));
+
+      return res.json({ items, total });
+    } catch (err) {
+      req.log?.error?.(err, 'integration_events_list_failed');
+      return res.status(500).json({
+        error: 'list_events_failed',
+        message: 'Falha ao listar eventos de integrações.',
+      });
+    }
+  });
+
+  return router;
+}
+
+export default createIntegrationsEventsRouter;

--- a/backend/routes/integrations.js
+++ b/backend/routes/integrations.js
@@ -133,15 +133,16 @@ async function ensureOrgContext(req, db) {
   throw err;
 }
 
-function getRateLimitKey(req) {
-  return (
-    req.headers['x-org-id'] ||
-    req.user?.org_id ||
-    req.orgId ||
-    req.headers['x-impersonate-org-id'] ||
-    req.ip ||
-    'anonymous'
-  );
+function getRateLimitKey(req, res) {
+  const orgScopedKey =
+    req.headers['x-org-id'] || req.user?.org_id || req.orgId || req.headers['x-impersonate-org-id'];
+  if (orgScopedKey) {
+    return orgScopedKey;
+  }
+  if (typeof rateLimit.ipKeyGenerator === 'function') {
+    return rateLimit.ipKeyGenerator(req, res);
+  }
+  return req.ip || 'anonymous';
 }
 
 function mapValidationError(err) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -43,6 +43,7 @@ import whatsappRouter from './routes/whatsapp.js';
 import whatsappTemplatesRouter from './routes/whatsapp_templates.js';
 import agendaRouter from './routes/agenda_whatsapp.js';
 import { createIntegrationsRouter } from './routes/integrations.js';
+import { createIntegrationsEventsRouter } from './routes/integrations.events.js';
 import clientsRouter from './routes/clients.js';
 import waCloudIntegrationRouter from './routes/integrations/whatsapp.cloud.js';
 import waSessionIntegrationRouter from './routes/integrations/whatsapp.session.js';
@@ -138,6 +139,8 @@ const integrationsRouter = createIntegrationsRouter({
   seal,
   open,
 });
+const integrationsEventsRouter = createIntegrationsEventsRouter({ logger });
+const integrationsRoleGuard = requireRole(['OrgAdmin', 'OrgOwner']);
 
 function getDbHealthcheckConfig() {
   return resolveDbHealthcheckConfig(process.env);
@@ -370,7 +373,13 @@ function configureApp() {
   app.use('/', telemetryRouter);
   app.use('/', handoffRouter);
 
-  app.use('/api/integrations', authRequired, requireRole(['OrgAdmin', 'OrgOwner']), integrationsRouter);
+  app.use(
+    '/api/integrations',
+    authRequired,
+    integrationsRoleGuard,
+    integrationsEventsRouter,
+    integrationsRouter
+  );
   app.use('/api/integrations/whatsapp/cloud', waCloudIntegrationRouter);
   app.use('/api/integrations/whatsapp/session', waSessionIntegrationRouter);
   app.use('/api/integrations/meta', metaOauthIntegrationRouter);

--- a/backend/test/integrations.events.spec.mjs
+++ b/backend/test/integrations.events.spec.mjs
@@ -1,0 +1,166 @@
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'node:crypto';
+import { createIntegrationsEventsRouter } from '../routes/integrations.events.js';
+import { authRequired } from '../middleware/auth.js';
+import { requireRole } from '../middleware/requireRole.js';
+import { createTestDb } from './utils/db.mem.mjs';
+import { runMigrations } from './utils/runMigrations.mjs';
+
+const fakeLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function authHeader(token) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+function getErrorBody(response) {
+  try {
+    return response.body;
+  } catch {
+    return {};
+  }
+}
+
+describe('integrations events router', () => {
+  let db;
+  let app;
+  let orgId;
+  let otherOrgId;
+  let adminToken;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'dev-secret';
+    db = createTestDb();
+    await runMigrations({ db });
+    orgId = randomUUID();
+    otherOrgId = randomUUID();
+    await db.query(`INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3)`, [
+      orgId,
+      'Org Test',
+      'org-test',
+    ]);
+    await db.query(`INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3)`, [
+      otherOrgId,
+      'Org B',
+      'org-b',
+    ]);
+    adminToken = jwt.sign(
+      {
+        id: 'user-1',
+        org_id: orgId,
+        role: 'OrgAdmin',
+        roles: [],
+      },
+      process.env.JWT_SECRET
+    );
+
+    app = buildApp();
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    await db.query('TRUNCATE integration_events RESTART IDENTITY CASCADE');
+  });
+
+  function buildApp() {
+    const application = express();
+    application.use(express.json());
+    application.use((req, _res, next) => {
+      req.db = db;
+      next();
+    });
+    const router = createIntegrationsEventsRouter({ logger: fakeLogger });
+    const guard = requireRole('OrgAdmin', 'OrgOwner');
+    application.use('/api/integrations', authRequired, guard, router);
+    application.use((err, _req, res, _next) => {
+      res.status(500).json({ error: 'unhandled', message: err.message });
+    });
+    return application;
+  }
+
+  async function insertEvent({ org = orgId, provider, payload = {}, eventType = null, receivedAt }) {
+    const date = receivedAt || new Date();
+    await db.query(
+      `INSERT INTO integration_events (org_id, provider, payload, event_type, received_at)
+       VALUES ($1, $2, $3::jsonb, $4, $5)`,
+      [org, provider, JSON.stringify(payload), eventType, date.toISOString()]
+    );
+  }
+
+  it('returns events filtered by provider with pagination', async () => {
+    await insertEvent({
+      provider: 'meta_facebook',
+      payload: { message: 'first', access_token: 'secret-token' },
+      eventType: 'messages',
+      receivedAt: new Date(Date.now() - 1000 * 60),
+    });
+    await insertEvent({
+      provider: 'meta_facebook',
+      payload: { message: 'second' },
+      eventType: 'messages',
+      receivedAt: new Date(),
+    });
+    await insertEvent({
+      provider: 'meta_instagram',
+      payload: { message: 'ignored' },
+      eventType: 'messages',
+    });
+
+    const response = await request(app)
+      .get('/api/integrations/events?provider=meta_facebook&limit=2')
+      .set(authHeader(adminToken));
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body.items)).toBe(true);
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.total).toBeGreaterThanOrEqual(2);
+    for (const item of response.body.items) {
+      expect(item.provider).toBe('meta_facebook');
+      expect(item.summary).toBeTruthy();
+      if (item.payload?.access_token) {
+        expect(item.payload.access_token).toBe('[REDACTED]');
+      }
+    }
+  });
+
+  it('respects orgId filter and excludes events from other orgs', async () => {
+    await insertEvent({
+      provider: 'meta_facebook',
+      payload: { message: 'primary org' },
+    });
+    await insertEvent({
+      org: otherOrgId,
+      provider: 'meta_facebook',
+      payload: { message: 'other org' },
+    });
+
+    const defaultOrgResponse = await request(app)
+      .get('/api/integrations/events?provider=meta_facebook&limit=10')
+      .set(authHeader(adminToken));
+
+    expect(defaultOrgResponse.status).toBe(200);
+    expect(defaultOrgResponse.body.items.every((item) => item.org_id === orgId)).toBe(true);
+
+    const otherOrgResponse = await request(app)
+      .get(`/api/integrations/events?provider=meta_facebook&limit=10&orgId=${otherOrgId}`)
+      .set(authHeader(adminToken));
+
+    expect(otherOrgResponse.status).toBe(200);
+    expect(otherOrgResponse.body.items.every((item) => item.org_id === otherOrgId)).toBe(true);
+    expect(otherOrgResponse.body.items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('requires authentication', async () => {
+    const response = await request(app).get('/api/integrations/events');
+    expect(response.status).toBe(401);
+    expect(getErrorBody(response)).toHaveProperty('error');
+  });
+});

--- a/backend/test/integrations.ratelimit.spec.mjs
+++ b/backend/test/integrations.ratelimit.spec.mjs
@@ -1,0 +1,130 @@
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'node:crypto';
+import { jest } from '@jest/globals';
+import { createIntegrationsRouter } from '../routes/integrations.js';
+import { authRequired } from '../middleware/auth.js';
+import { requireRole } from '../middleware/requireRole.js';
+import { createTestDb } from './utils/db.mem.mjs';
+import { runMigrations } from './utils/runMigrations.mjs';
+
+const fakeSeal = (value = {}) => ({
+  c: Buffer.from(JSON.stringify(value), 'utf8').toString('base64'),
+  v: 1,
+});
+
+const fakeOpen = (sealed) => {
+  if (!sealed || typeof sealed !== 'object') return {};
+  if (typeof sealed.c === 'string') {
+    try {
+      const json = Buffer.from(sealed.c, 'base64').toString('utf8');
+      return JSON.parse(json);
+    } catch {
+      return {};
+    }
+  }
+  return { ...sealed };
+};
+
+const fakeLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+describe('integrations router rate limit', () => {
+  let db;
+  let app;
+  let orgId;
+  let adminToken;
+  const httpClient = { post: jest.fn(), request: jest.fn() };
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'dev-secret';
+    db = createTestDb();
+    await runMigrations({ db });
+    orgId = randomUUID();
+    await db.query(`INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3)`, [
+      orgId,
+      'Org Test',
+      'org-test',
+    ]);
+    const sealedCreds = fakeSeal({
+      calendarId: 'primary',
+      clientEmail: 'bot@example.com',
+      privateKey: '-----BEGIN PRIVATE KEY-----abc1234567890',
+      timezone: 'America/Sao_Paulo',
+    });
+    await db.query(
+      `INSERT INTO org_integrations (org_id, provider, status, subscribed, creds, meta)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb)
+       ON CONFLICT (org_id, provider)
+       DO UPDATE SET status = EXCLUDED.status, subscribed = EXCLUDED.subscribed, creds = EXCLUDED.creds, meta = EXCLUDED.meta`,
+      [orgId, 'google_calendar', 'connected', true, JSON.stringify(sealedCreds), JSON.stringify({})]
+    );
+    adminToken = jwt.sign(
+      {
+        id: 'user-1',
+        org_id: orgId,
+        role: 'OrgAdmin',
+        roles: [],
+      },
+      process.env.JWT_SECRET
+    );
+    app = buildApp();
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  beforeEach(() => {
+    httpClient.post.mockReset();
+    httpClient.post.mockResolvedValue({ status: 200, data: {} });
+  });
+
+  function buildApp() {
+    const application = express();
+    application.use(express.json());
+    application.use((req, _res, next) => {
+      req.db = db;
+      next();
+    });
+    const router = createIntegrationsRouter({
+      db,
+      seal: fakeSeal,
+      open: fakeOpen,
+      logger: fakeLogger,
+      httpClient,
+      rateLimitOptions: {
+        windowMs: 1_000,
+        limit: 2,
+      },
+    });
+    const guard = requireRole('OrgAdmin', 'OrgOwner');
+    application.use('/api/integrations', authRequired, guard, router);
+    application.use((err, _req, res, _next) => {
+      res.status(500).json({ error: 'unhandled', message: err.message });
+    });
+    return application;
+  }
+
+  function authHeader(token) {
+    return { Authorization: `Bearer ${token}` };
+  }
+
+  it('responds with 429 after hitting the rate limit', async () => {
+    const endpoint = '/api/integrations/providers/google_calendar/test';
+
+    const first = await request(app).post(endpoint).set(authHeader(adminToken));
+    expect(first.status).toBe(200);
+
+    const second = await request(app).post(endpoint).set(authHeader(adminToken));
+    expect(second.status).toBe(200);
+
+    const third = await request(app).post(endpoint).set(authHeader(adminToken));
+    expect(third.status).toBe(429);
+    expect(third.body).toMatchObject({ error: 'rate_limited' });
+  });
+});

--- a/backend/test/utils/runMigrations.mjs
+++ b/backend/test/utils/runMigrations.mjs
@@ -8,6 +8,7 @@ const __dirname = dirname(__filename);
 const MIGRATIONS = [
   '../../migrations/2025-09-29_organizations_and_plan_credits.sql',
   '../../db/migrations/20250930_integrations_core.sql',
+  '../../db/migrations/20251015_integration_events.sql',
 ];
 
 function stripUnsupportedBlocks(sql) {

--- a/docs/integrations.http
+++ b/docs/integrations.http
@@ -1,0 +1,9 @@
+### Status geral
+GET http://localhost:4000/api/integrations/status
+Authorization: Bearer {{TOKEN}}
+X-Org-Id: {{ORG}}
+
+### Eventos (primeiros 10 do WhatsApp Cloud)
+GET http://localhost:4000/api/integrations/events?provider=whatsapp_cloud&limit=10
+Authorization: Bearer {{TOKEN}}
+X-Org-Id: {{ORG}}

--- a/docs/integrations.postman.json
+++ b/docs/integrations.postman.json
@@ -1,0 +1,47 @@
+{
+  "info": {
+    "name": "Cresceja Integrações",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Coleção básica para testar integrações via API."
+  },
+  "item": [
+    {
+      "name": "Status geral",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Authorization", "value": "Bearer {{TOKEN}}" },
+          { "key": "X-Org-Id", "value": "{{ORG}}" }
+        ],
+        "url": {
+          "raw": "http://localhost:4000/api/integrations/status",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "4000",
+          "path": ["api", "integrations", "status"]
+        }
+      }
+    },
+    {
+      "name": "Eventos WhatsApp Cloud",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Authorization", "value": "Bearer {{TOKEN}}" },
+          { "key": "X-Org-Id", "value": "{{ORG}}" }
+        ],
+        "url": {
+          "raw": "http://localhost:4000/api/integrations/events?provider=whatsapp_cloud&limit=10",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "4000",
+          "path": ["api", "integrations", "events"],
+          "query": [
+            { "key": "provider", "value": "whatsapp_cloud" },
+            { "key": "limit", "value": "10" }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/frontend/src/api/integrationsApi.js
+++ b/frontend/src/api/integrationsApi.js
@@ -20,6 +20,18 @@ export const disconnectProvider = (provider) =>
     .post(`/api/integrations/providers/${provider}/disconnect`)
     .then((r) => r.data);
 
+export const listEvents = ({ provider, limit, offset, start, end } = {}) => {
+  const params = new URLSearchParams();
+  if (provider) params.set('provider', provider);
+  if (typeof limit === 'number') params.set('limit', String(limit));
+  if (typeof offset === 'number') params.set('offset', String(offset));
+  if (start) params.set('start', start);
+  if (end) params.set('end', end);
+  const query = params.toString();
+  const url = query ? `/api/integrations/events?${query}` : '/api/integrations/events';
+  return inboxApi.get(url).then((r) => r.data);
+};
+
 export default {
   getAllStatus,
   getProviderStatus,
@@ -27,4 +39,5 @@ export default {
   subscribeProvider,
   testProvider,
   disconnectProvider,
+  listEvents,
 };

--- a/frontend/src/components/settings/FacebookCard.jsx
+++ b/frontend/src/components/settings/FacebookCard.jsx
@@ -10,6 +10,9 @@ import useToast from '@/hooks/useToastFallback.js';
 import { useOrg } from '@/contexts/OrgContext.jsx';
 import StatusPill from './StatusPill.jsx';
 import InlineSpinner from '../InlineSpinner.jsx';
+import { getToastMessages, resolveIntegrationError } from './integrationMessages.js';
+
+const toastMessages = getToastMessages('facebook');
 
 export default function FacebookCard() {
   const toast = useToast();
@@ -33,8 +36,7 @@ export default function FacebookCard() {
 
   const canConnect = useMemo(() => Boolean(form.accessToken.trim()), [form.accessToken]);
 
-  const getErrorMessage = (error, fallback) =>
-    error?.response?.data?.message || error?.message || fallback;
+  const getErrorMessage = (error, fallbackKey) => resolveIntegrationError(error, fallbackKey);
 
   const applyIntegration = (integration) => {
     if (!integration) return;
@@ -79,7 +81,7 @@ export default function FacebookCard() {
           ...prev,
           loading: false,
           status: 'error',
-          lastError: getErrorMessage(err, 'Falha ao carregar status'),
+          lastError: getErrorMessage(err, 'load_status'),
         }));
       }
     })();
@@ -99,16 +101,16 @@ export default function FacebookCard() {
       const integration = response?.integration || response;
       applyIntegration(integration);
       setState((prev) => ({ ...prev, saving: false }));
-      toast({ title: 'Facebook conectado', description: org?.name });
+      toast({ title: toastMessages.connect_success || 'Facebook conectado', description: org?.name });
     } catch (err) {
-      const message = getErrorMessage(err, 'Falha ao conectar');
+      const message = getErrorMessage(err, 'connect');
       setState((prev) => ({
         ...prev,
         saving: false,
         status: 'error',
         lastError: message,
       }));
-      toast({ title: 'Erro ao conectar Facebook', description: message });
+      toast({ title: toastMessages.connect_error || 'Erro ao conectar Facebook', description: message });
     }
   };
 
@@ -119,15 +121,15 @@ export default function FacebookCard() {
       const integration = response?.integration || response;
       applyIntegration(integration);
       setState((prev) => ({ ...prev, subscribing: false }));
-      toast({ title: 'Webhook do Facebook ativo' });
+      toast({ title: toastMessages.subscribe_success || 'Webhook do Facebook ativo' });
     } catch (err) {
-      const message = getErrorMessage(err, 'Falha ao assinar webhook');
+      const message = getErrorMessage(err, 'subscribe');
       setState((prev) => ({
         ...prev,
         subscribing: false,
         lastError: message,
       }));
-      toast({ title: 'Erro ao assinar webhook', description: message });
+      toast({ title: toastMessages.subscribe_error || 'Erro ao assinar webhook', description: message });
     }
   };
 
@@ -138,15 +140,15 @@ export default function FacebookCard() {
       const integration = response?.integration || response;
       applyIntegration(integration);
       setState((prev) => ({ ...prev, testing: false }));
-      toast({ title: 'Teste enviado', description: 'Simulação de publicação concluída.' });
+      toast({ title: toastMessages.test_success || 'Teste enviado', description: 'Simulação de publicação concluída.' });
     } catch (err) {
-      const message = getErrorMessage(err, 'Falha ao testar');
+      const message = getErrorMessage(err, 'test');
       setState((prev) => ({
         ...prev,
         testing: false,
         lastError: message,
       }));
-      toast({ title: 'Erro no teste', description: message });
+      toast({ title: toastMessages.test_error || 'Erro no teste', description: message });
     }
   };
 
@@ -162,15 +164,15 @@ export default function FacebookCard() {
         status: integration?.status || 'disconnected',
         subscribed: false,
       }));
-      toast({ title: 'Facebook desconectado' });
+      toast({ title: toastMessages.disconnect_success || 'Facebook desconectado' });
     } catch (err) {
-      const message = getErrorMessage(err, 'Falha ao desconectar');
+      const message = getErrorMessage(err, 'disconnect');
       setState((prev) => ({
         ...prev,
         disconnecting: false,
         lastError: message,
       }));
-      toast({ title: 'Erro ao desconectar', description: message });
+      toast({ title: toastMessages.disconnect_error || 'Erro ao desconectar Facebook', description: message });
     }
   };
 
@@ -238,6 +240,10 @@ export default function FacebookCard() {
         </label>
       </div>
 
+      <div aria-live="polite" role="status" className="sr-only">
+        {state.lastError ? String(state.lastError) : ''}
+      </div>
+
       {state.lastError ? (
         <div className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800" data-testid="facebook-error">
           {String(state.lastError)}
@@ -250,6 +256,7 @@ export default function FacebookCard() {
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
           onClick={handleConnect}
           disabled={!canConnect || state.saving}
+          aria-busy={state.saving}
         >
           {renderActionLabel(state.saving, 'Conectar', 'Conectando…')}
         </button>
@@ -258,6 +265,7 @@ export default function FacebookCard() {
           className="rounded-lg border px-4 py-2 text-sm font-medium transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
           onClick={handleSubscribe}
           disabled={state.subscribing || state.status === 'disconnected'}
+          aria-busy={state.subscribing}
         >
           {renderActionLabel(state.subscribing, 'Assinar webhook', 'Assinando…')}
         </button>
@@ -266,6 +274,7 @@ export default function FacebookCard() {
           className="rounded-lg border px-4 py-2 text-sm font-medium transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
           onClick={handleTest}
           disabled={state.testing || state.status === 'disconnected'}
+          aria-busy={state.testing}
         >
           {renderActionLabel(state.testing, 'Testar', 'Testando…')}
         </button>
@@ -274,6 +283,7 @@ export default function FacebookCard() {
           className="rounded-lg border px-4 py-2 text-sm font-medium transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
           onClick={handleDisconnect}
           disabled={state.disconnecting || state.status === 'disconnected'}
+          aria-busy={state.disconnecting}
         >
           {renderActionLabel(state.disconnecting, 'Desconectar', 'Desconectando…')}
         </button>

--- a/frontend/src/components/settings/StatusPill.jsx
+++ b/frontend/src/components/settings/StatusPill.jsx
@@ -1,12 +1,34 @@
 import React from 'react';
+import { getIntegrationDictionary } from '@/i18n/integrations.js';
+
+const messages = getIntegrationDictionary();
+const statusLabels = messages.status || {};
 
 const STATUS_MAP = {
-  connected: { label: 'Conectado', className: 'bg-emerald-100 text-emerald-700 border border-emerald-200' },
-  disconnected: { label: 'Desconectado', className: 'bg-gray-100 text-gray-600 border border-gray-200' },
-  pending: { label: 'Pendente', className: 'bg-amber-100 text-amber-700 border border-amber-200' },
-  connecting: { label: 'Conectando…', className: 'bg-amber-100 text-amber-700 border border-amber-200' },
-  error: { label: 'Erro', className: 'bg-rose-100 text-rose-700 border border-rose-200' },
-  unknown: { label: 'Indefinido', className: 'bg-gray-100 text-gray-600 border border-gray-200' },
+  connected: {
+    label: statusLabels.connected || 'Conectado',
+    className: 'bg-emerald-100 text-emerald-700 border border-emerald-200',
+  },
+  disconnected: {
+    label: statusLabels.disconnected || 'Desconectado',
+    className: 'bg-gray-100 text-gray-600 border border-gray-200',
+  },
+  pending: {
+    label: statusLabels.pending || 'Pendente',
+    className: 'bg-amber-100 text-amber-700 border border-amber-200',
+  },
+  connecting: {
+    label: statusLabels.connecting || 'Conectando…',
+    className: 'bg-amber-100 text-amber-700 border border-amber-200',
+  },
+  error: {
+    label: statusLabels.error || 'Erro',
+    className: 'bg-rose-100 text-rose-700 border border-rose-200',
+  },
+  unknown: {
+    label: statusLabels.unknown || 'Indefinido',
+    className: 'bg-gray-100 text-gray-600 border border-gray-200',
+  },
 };
 
 export default function StatusPill({ status }) {

--- a/frontend/src/components/settings/integrationMessages.js
+++ b/frontend/src/components/settings/integrationMessages.js
@@ -1,0 +1,17 @@
+import { getIntegrationDictionary } from '@/i18n/integrations.js';
+
+const dictionary = getIntegrationDictionary();
+
+export function getIntegrationMessages() {
+  return dictionary;
+}
+
+export function resolveIntegrationError(error, fallbackKey) {
+  const errors = dictionary.errors || {};
+  const generic = errors.generic || 'Falha ao completar a ação. Tente novamente.';
+  return error?.response?.data?.message || error?.message || errors[fallbackKey] || generic;
+}
+
+export function getToastMessages(providerKey) {
+  return (dictionary.toasts && dictionary.toasts[providerKey]) || {};
+}

--- a/frontend/src/i18n/integrations.js
+++ b/frontend/src/i18n/integrations.js
@@ -1,0 +1,24 @@
+import messages from './integrations.json';
+
+export const DEFAULT_INTEGRATIONS_LOCALE = 'pt-BR';
+
+export function getIntegrationDictionary(locale = DEFAULT_INTEGRATIONS_LOCALE) {
+  return messages[locale] || messages[DEFAULT_INTEGRATIONS_LOCALE] || {};
+}
+
+export function translateIntegration(path, { locale = DEFAULT_INTEGRATIONS_LOCALE, fallback, vars } = {}) {
+  const dictionary = getIntegrationDictionary(locale);
+  const value = path
+    .split('.')
+    .reduce((acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined), dictionary);
+  if (typeof value === 'string') {
+    if (!vars) return value;
+    return value.replace(/{{\s*(\w+)\s*}}/g, (_match, token) => {
+      if (Object.prototype.hasOwnProperty.call(vars, token)) {
+        return String(vars[token]);
+      }
+      return '';
+    });
+  }
+  return value !== undefined ? value : fallback;
+}

--- a/frontend/src/i18n/integrations.json
+++ b/frontend/src/i18n/integrations.json
@@ -1,0 +1,94 @@
+{
+  "pt-BR": {
+    "status": {
+      "connected": "Conectado",
+      "disconnected": "Desconectado",
+      "pending": "Pendente",
+      "connecting": "Conectando…",
+      "error": "Erro",
+      "unknown": "Indefinido"
+    },
+    "errors": {
+      "generic": "Falha ao completar a ação. Tente novamente.",
+      "load_status": "Falha ao carregar status.",
+      "connect": "Falha ao conectar.",
+      "subscribe": "Falha ao assinar webhook.",
+      "test": "Falha ao executar teste.",
+      "disconnect": "Falha ao desconectar."
+    },
+    "toasts": {
+      "whatsapp_cloud": {
+        "connect_success": "WhatsApp Cloud conectado",
+        "connect_error": "Erro ao conectar WhatsApp Cloud",
+        "subscribe_success": "Webhook assinado com sucesso",
+        "subscribe_error": "Erro ao assinar webhook",
+        "test_success": "Mensagem de teste enviada",
+        "test_error": "Erro no teste",
+        "disconnect_success": "WhatsApp Cloud desconectado",
+        "disconnect_error": "Erro ao desconectar WhatsApp Cloud"
+      },
+      "whatsapp_session": {
+        "connect_success": "Sessão WhatsApp iniciada",
+        "connect_error": "Erro ao iniciar sessão",
+        "test_success": "Mensagem de teste enviada",
+        "test_error": "Erro no teste",
+        "disconnect_success": "Sessão encerrada",
+        "disconnect_error": "Erro ao desconectar sessão"
+      },
+      "instagram": {
+        "connect_success": "Instagram conectado",
+        "connect_error": "Erro ao conectar Instagram",
+        "subscribe_success": "Webhook do Instagram ativo",
+        "subscribe_error": "Erro ao assinar webhook",
+        "test_success": "Teste enviado",
+        "test_error": "Erro no teste",
+        "disconnect_success": "Instagram desconectado",
+        "disconnect_error": "Erro ao desconectar Instagram"
+      },
+      "facebook": {
+        "connect_success": "Facebook conectado",
+        "connect_error": "Erro ao conectar Facebook",
+        "subscribe_success": "Webhook do Facebook ativo",
+        "subscribe_error": "Erro ao assinar webhook",
+        "test_success": "Teste enviado",
+        "test_error": "Erro no teste",
+        "disconnect_success": "Facebook desconectado",
+        "disconnect_error": "Erro ao desconectar Facebook"
+      },
+      "google_calendar": {
+        "connect_success": "Google Calendar conectado",
+        "connect_error": "Falha ao conectar Google Calendar",
+        "test_success": "Teste enviado",
+        "test_error": "Erro ao testar Google Calendar",
+        "disconnect_success": "Google Calendar desconectado",
+        "disconnect_error": "Erro ao desconectar Google Calendar"
+      },
+      "events": {
+        "load_error": "Erro ao carregar eventos de integrações"
+      }
+    },
+    "events": {
+      "title": "Eventos de Integrações",
+      "empty": "Nenhum evento encontrado no período selecionado.",
+      "provider_all": "Todos os provedores",
+      "period_all": "Todo o período",
+      "period_last_24h": "Últimas 24h",
+      "period_last_7d": "Últimos 7 dias",
+      "period_last_30d": "Últimos 30 dias",
+      "received_at": "Recebido em",
+      "provider": "Provedor",
+      "event_type": "Tipo de evento",
+      "summary": "Resumo",
+      "actions": "Ações",
+      "view_json": "Ver JSON",
+      "modal_title": "Detalhes do evento",
+      "close": "Fechar",
+      "loading": "Carregando eventos…"
+    },
+    "pagination": {
+      "showing": "Mostrando {{start}}-{{end}} de {{total}}",
+      "previous": "Anterior",
+      "next": "Próximo"
+    }
+  }
+}

--- a/frontend/src/pages/IntegrationsPage.jsx
+++ b/frontend/src/pages/IntegrationsPage.jsx
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import WhatsAppOfficialCard from '@/components/settings/WhatsAppOfficialCard.jsx';
 import WhatsAppBaileysCard from '@/components/settings/WhatsAppBaileysCard.jsx';
 import InstagramCard from '@/components/settings/InstagramCard.jsx';
 import FacebookCard from '@/components/settings/FacebookCard.jsx';
 import GoogleCalendarCard from '@/components/settings/GoogleCalendarCard.jsx';
+import IntegrationEvents from '@/pages/integrations/IntegrationEvents.jsx';
 
 export default function IntegrationsPage() {
+  const [activeTab, setActiveTab] = useState('providers');
+
+  const handleSelectTab = (tab) => () => {
+    setActiveTab(tab);
+  };
+
   return (
     <div className="space-y-6 p-6" data-testid="integrations-page">
       <header className="space-y-2">
@@ -14,13 +21,50 @@ export default function IntegrationsPage() {
           Conecte canais oficiais e calendários para automatizar a sua operação.
         </p>
       </header>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-        <WhatsAppOfficialCard />
-        <WhatsAppBaileysCard />
-        <InstagramCard />
-        <FacebookCard />
-        <GoogleCalendarCard />
+      <div role="tablist" aria-label="Configurações de integrações" className="flex gap-2">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'providers'}
+          id="integrations-tab-providers"
+          onClick={handleSelectTab('providers')}
+          className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+            activeTab === 'providers'
+              ? 'bg-blue-600 text-white shadow'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          }`}
+        >
+          Provedores
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'events'}
+          id="integrations-tab-events"
+          onClick={handleSelectTab('events')}
+          className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+            activeTab === 'events'
+              ? 'bg-blue-600 text-white shadow'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          }`}
+        >
+          Eventos
+        </button>
       </div>
+
+      {activeTab === 'providers' ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3" role="tabpanel" aria-labelledby="integrations-tab-providers">
+          <WhatsAppOfficialCard />
+          <WhatsAppBaileysCard />
+          <InstagramCard />
+          <FacebookCard />
+          <GoogleCalendarCard />
+        </div>
+      ) : (
+        <div role="tabpanel" aria-labelledby="integrations-tab-events">
+          <IntegrationEvents />
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/integrations/IntegrationEvents.jsx
+++ b/frontend/src/pages/integrations/IntegrationEvents.jsx
@@ -1,0 +1,321 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { listEvents } from '@/api/integrationsApi.js';
+import useToast from '@/hooks/useToastFallback.js';
+import InlineSpinner from '@/components/InlineSpinner.jsx';
+import { getIntegrationDictionary, translateIntegration } from '@/i18n/integrations.js';
+
+const LIMIT = 20;
+const dictionary = getIntegrationDictionary();
+const eventMessages = dictionary.events || {};
+const toastMessages = dictionary.toasts?.events || {};
+const errorMessages = dictionary.errors || {};
+
+const PROVIDER_OPTIONS = [
+  { value: '', label: eventMessages.provider_all || 'Todos os provedores' },
+  { value: 'whatsapp_cloud', label: 'WhatsApp Cloud' },
+  { value: 'whatsapp_session', label: 'WhatsApp Sessão' },
+  { value: 'meta_instagram', label: 'Instagram' },
+  { value: 'meta_facebook', label: 'Facebook' },
+  { value: 'google_calendar', label: 'Google Calendar' },
+];
+
+const PERIOD_OPTIONS = [
+  {
+    value: '24h',
+    label: eventMessages.period_last_24h || 'Últimas 24h',
+    range: () => [new Date(Date.now() - 24 * 60 * 60 * 1000), new Date()],
+  },
+  {
+    value: '7d',
+    label: eventMessages.period_last_7d || 'Últimos 7 dias',
+    range: () => [new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), new Date()],
+  },
+  {
+    value: '30d',
+    label: eventMessages.period_last_30d || 'Últimos 30 dias',
+    range: () => [new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), new Date()],
+  },
+  {
+    value: 'all',
+    label: eventMessages.period_all || 'Todo o período',
+    range: () => [null, null],
+  },
+];
+
+const providerLabelMap = PROVIDER_OPTIONS.reduce((acc, option) => {
+  if (option.value) acc[option.value] = option.label;
+  return acc;
+}, {});
+
+function formatDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'medium',
+  }).format(date);
+}
+
+function getRange(period) {
+  const option = PERIOD_OPTIONS.find((item) => item.value === period) || PERIOD_OPTIONS[1];
+  const [start, end] = option.range();
+  return {
+    start: start ? start.toISOString() : undefined,
+    end: end ? end.toISOString() : undefined,
+  };
+}
+
+function buildPaginationLabel({ page, total, count }) {
+  const start = total === 0 ? 0 : page * LIMIT + 1;
+  const end = total === 0 ? 0 : page * LIMIT + count;
+  return (
+    translateIntegration('pagination.showing', {
+      fallback: `Mostrando ${start}-${end} de ${total}`,
+      vars: { start, end, total },
+    }) || ''
+  );
+}
+
+const genericErrorMessage = errorMessages.generic || 'Falha ao completar a ação. Tente novamente.';
+
+export default function IntegrationEvents() {
+  const toast = useToast();
+  const [provider, setProvider] = useState('');
+  const [period, setPeriod] = useState('7d');
+  const [page, setPage] = useState(0);
+  const [items, setItems] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [selectedEvent, setSelectedEvent] = useState(null);
+
+  const { start, end } = useMemo(() => getRange(period), [period]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadEvents() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await listEvents({
+          provider: provider || undefined,
+          limit: LIMIT,
+          offset: page * LIMIT,
+          start,
+          end,
+        });
+        if (cancelled) return;
+        setItems(Array.isArray(response?.items) ? response.items : []);
+        setTotal(Number(response?.total) || 0);
+      } catch (err) {
+        if (cancelled) return;
+        const message =
+          err?.response?.data?.message || err?.message || toastMessages.load_error || genericErrorMessage;
+        setItems([]);
+        setTotal(0);
+        setError(message);
+        toast({ title: toastMessages.load_error || eventMessages.title || 'Eventos de Integrações', description: message });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    loadEvents();
+    return () => {
+      cancelled = true;
+    };
+  }, [provider, period, page, start, end, toast]);
+
+  const hasNextPage = (page + 1) * LIMIT < total;
+  const paginationLabel = buildPaginationLabel({ page, total, count: items.length });
+
+  const handleProviderChange = (event) => {
+    setProvider(event.target.value);
+    setPage(0);
+  };
+
+  const handlePeriodChange = (event) => {
+    setPeriod(event.target.value);
+    setPage(0);
+  };
+
+  const handlePrevPage = () => {
+    setPage((prev) => Math.max(0, prev - 1));
+  };
+
+  const handleNextPage = () => {
+    if (hasNextPage) {
+      setPage((prev) => prev + 1);
+    }
+  };
+
+  return (
+    <div className="space-y-4" data-testid="integration-events">
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold">{eventMessages.title || 'Eventos de Integrações'}</h2>
+        <p className="text-sm text-gray-500">
+          {provider ? providerLabelMap[provider] || provider : eventMessages.provider_all || 'Todos os provedores'}
+        </p>
+      </header>
+
+      <div className="flex flex-wrap items-end gap-4" data-testid="integration-events-filters">
+        <label className="grid gap-1 text-sm" htmlFor="integration-events-provider">
+          <span className="font-medium">{eventMessages.provider || 'Provedor'}</span>
+          <select
+            id="integration-events-provider"
+            className="rounded-lg border px-3 py-2"
+            value={provider}
+            onChange={handleProviderChange}
+            disabled={loading}
+          >
+            {PROVIDER_OPTIONS.map((option) => (
+              <option key={option.value || 'all'} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="grid gap-1 text-sm" htmlFor="integration-events-period">
+          <span className="font-medium">Período</span>
+          <select
+            id="integration-events-period"
+            className="rounded-lg border px-3 py-2"
+            value={period}
+            onChange={handlePeriodChange}
+            disabled={loading}
+          >
+            {PERIOD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div aria-live="polite" role="status" className="sr-only">
+        {error ? String(error) : ''}
+      </div>
+
+      {error ? (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700" data-testid="integration-events-error">
+          {String(error)}
+        </div>
+      ) : null}
+
+      <div className="overflow-hidden rounded-2xl border bg-white shadow-sm">
+        <div className="relative">
+          {loading ? (
+            <div className="flex items-center justify-center gap-3 p-8" data-testid="integration-events-loading">
+              <InlineSpinner />
+              <span className="text-sm text-gray-500">{eventMessages.loading || 'Carregando eventos…'}</span>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="p-8 text-center text-sm text-gray-500" data-testid="integration-events-empty">
+              {eventMessages.empty || 'Nenhum evento encontrado no período selecionado.'}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 text-sm" data-testid="integration-events-table">
+                <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  <tr>
+                    <th scope="col" className="px-4 py-3">
+                      {eventMessages.received_at || 'Recebido em'}
+                    </th>
+                    <th scope="col" className="px-4 py-3">
+                      {eventMessages.provider || 'Provedor'}
+                    </th>
+                    <th scope="col" className="px-4 py-3">
+                      {eventMessages.event_type || 'Tipo de evento'}
+                    </th>
+                    <th scope="col" className="px-4 py-3">
+                      {eventMessages.summary || 'Resumo'}
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-right">
+                      {eventMessages.actions || 'Ações'}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 bg-white">
+                  {items.map((item) => (
+                    <tr key={item.id} className="align-top">
+                      <td className="whitespace-nowrap px-4 py-3 text-gray-600">{formatDate(item.received_at)}</td>
+                      <td className="whitespace-nowrap px-4 py-3 text-gray-600">
+                        {providerLabelMap[item.provider] || item.provider || '—'}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-gray-600">
+                        {item.event_type || '—'}
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">
+                        {item.summary || (eventMessages.summary || 'Evento recebido')}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right">
+                        <button
+                          type="button"
+                          className="rounded-md border px-3 py-1 text-xs font-medium text-blue-600 transition hover:bg-blue-50"
+                          onClick={() => setSelectedEvent(item)}
+                        >
+                          {eventMessages.view_json || 'Ver JSON'}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3" data-testid="integration-events-pagination">
+        <p className="text-sm text-gray-500">{paginationLabel}</p>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="rounded-lg border px-3 py-1 text-sm font-medium transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={handlePrevPage}
+            disabled={loading || page === 0}
+          >
+            {translateIntegration('pagination.previous', { fallback: 'Anterior' })}
+          </button>
+          <button
+            type="button"
+            className="rounded-lg border px-3 py-1 text-sm font-medium transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={handleNextPage}
+            disabled={loading || !hasNextPage}
+          >
+            {translateIntegration('pagination.next', { fallback: 'Próximo' })}
+          </button>
+        </div>
+      </div>
+
+      {selectedEvent ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-xl">
+            <div className="flex items-center justify-between border-b px-4 py-3">
+              <h3 className="text-lg font-semibold">{eventMessages.modal_title || 'Detalhes do evento'}</h3>
+              <button
+                type="button"
+                className="rounded-full p-2 text-gray-500 transition hover:bg-gray-100"
+                onClick={() => setSelectedEvent(null)}
+                aria-label={eventMessages.close || 'Fechar'}
+              >
+                ✕
+              </button>
+            </div>
+            <div className="max-h-[70vh] overflow-auto px-4 py-3 text-sm">
+              <pre className="whitespace-pre-wrap break-all text-xs text-gray-700">
+                {JSON.stringify(selectedEvent.payload, null, 2)}
+              </pre>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/test/pages/IntegrationEvents.test.jsx
+++ b/frontend/test/pages/IntegrationEvents.test.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import IntegrationEvents from '@/pages/integrations/IntegrationEvents.jsx';
+import { listEvents } from '@/api/integrationsApi.js';
+
+jest.mock('@/api/integrationsApi.js', () => ({
+  listEvents: jest.fn(),
+}));
+
+describe('IntegrationEvents', () => {
+  beforeEach(() => {
+    listEvents.mockReset();
+  });
+
+  test('renders empty state when there are no events', async () => {
+    listEvents.mockResolvedValue({ items: [], total: 0 });
+    render(<IntegrationEvents />);
+
+    expect(await screen.findByTestId('integration-events-empty')).toBeInTheDocument();
+    expect(listEvents).toHaveBeenCalledWith({ provider: undefined, limit: 20, offset: 0, start: expect.any(String), end: expect.any(String) });
+  });
+
+  test('displays events and paginates correctly', async () => {
+    listEvents
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'evt-1',
+            provider: 'meta_facebook',
+            received_at: '2024-01-01T12:00:00Z',
+            event_type: 'messages',
+            summary: 'Mensagem recebida',
+            payload: { foo: 'bar' },
+          },
+        ],
+        total: 25,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'evt-2',
+            provider: 'meta_facebook',
+            received_at: '2024-01-01T11:00:00Z',
+            event_type: 'messages',
+            summary: 'Outro evento',
+            payload: {},
+          },
+        ],
+        total: 25,
+      });
+
+    render(<IntegrationEvents />);
+
+    expect(await screen.findByText('Mensagem recebida')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
+    await waitFor(() => {
+      expect(listEvents).toHaveBeenCalledTimes(2);
+      expect(listEvents).toHaveBeenLastCalledWith({
+        provider: undefined,
+        limit: 20,
+        offset: 20,
+        start: expect.any(String),
+        end: expect.any(String),
+      });
+    });
+  });
+
+  test('changes provider filter and refetches', async () => {
+    listEvents.mockResolvedValue({ items: [], total: 0 });
+    render(<IntegrationEvents />);
+
+    await waitFor(() => expect(listEvents).toHaveBeenCalledTimes(1));
+
+    await userEvent.selectOptions(screen.getByLabelText(/Provedor/i), 'meta_instagram');
+
+    await waitFor(() => {
+      expect(listEvents).toHaveBeenCalledTimes(2);
+      expect(listEvents).toHaveBeenLastCalledWith({
+        provider: 'meta_instagram',
+        limit: 20,
+        offset: 0,
+        start: expect.any(String),
+        end: expect.any(String),
+      });
+    });
+  });
+});

--- a/frontend/test/pages/SettingsPage.integrations.test.jsx
+++ b/frontend/test/pages/SettingsPage.integrations.test.jsx
@@ -12,6 +12,7 @@ jest.mock('@/api/integrationsApi.js', () => ({
   subscribeProvider: jest.fn(),
   testProvider: jest.fn(),
   disconnectProvider: jest.fn(),
+  listEvents: jest.fn().mockResolvedValue({ items: [], total: 0 }),
 }));
 
 describe('IntegrationsPage', () => {


### PR DESCRIPTION
## Summary
- add an authenticated /api/integrations/events router with filtering, sanitization and migration coverage plus rate limit tests
- surface an “Eventos” tab in the integrations page with provider filters, pagination and JSON drawer backed by the new listEvents API
- standardize integration setting toasts/i18n and add REST/Postman examples for integrations troubleshooting

## Testing
- npm run test -w backend
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dd207f4240832787f29877fdab9f1d