### PR TITLE
Add SSE token handshake for WhatsApp session QR modal

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,7 @@ CORS_ORIGINS=http://localhost:3000
 # ===== Auth =====
 JWT_SECRET=dev-change-me
 JWT_TEST_SECRET=dev
+SSE_TOKEN_SECRET=change-me
 
 # ===== Database =====
 DATABASE_URL=postgres://cresceja:cresceja123@localhost:5432/cresceja_db

--- a/frontend/src/api/integrationsApi.js
+++ b/frontend/src/api/integrationsApi.js
@@ -26,6 +26,11 @@ export const startBaileysQr = () =>
 export const stopBaileysQr = () =>
   inboxApi.post('/api/integrations/providers/whatsapp_session/qr/stop').then((r) => r.data);
 
+export const getBaileysSseToken = () =>
+  inboxApi
+    .post('/api/integrations/providers/whatsapp_session/qr/sse-token')
+    .then((r) => r.data);
+
 export const statusBaileys = () =>
   inboxApi.get('/api/integrations/providers/whatsapp_session/status').then((r) => r.data);
 
@@ -50,6 +55,7 @@ export default {
   disconnectProvider,
   startBaileysQr,
   stopBaileysQr,
+  getBaileysSseToken,
   statusBaileys,
   listEvents,
 };


### PR DESCRIPTION
## Summary
- add configuration and backend helpers to sign and verify short-lived SSE tokens for WhatsApp session streams
- expose an endpoint to issue SSE tokens and allow the WhatsApp session QR stream to authenticate with them
- add a frontend API helper and QR modal with reconnect/backoff that requests tokens before opening the stream

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2f77874c8327818177971b1ed175