### PR TITLE
Add backend CORS configuration and inbox stubs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,7 @@ PORT=4000
 BASE_URL=http://localhost:4000
 FRONTEND_URL=http://localhost:3000
 CORS_ORIGINS=http://localhost:3000
+CORS_ORIGIN=http://localhost:3000
 
 # ===== Auth =====
 JWT_SECRET=dev-change-me


### PR DESCRIPTION
## Summary
- enable configurable CORS middleware that supports credentials when the frontend runs on a different host
- add authenticated development stubs for inbox endpoints and org feature lookups so the built UI does not see 4xx errors while modules are disabled
- document the CORS_ORIGIN environment variable for backend deployments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4443a8bc8327a751cf6d8114e95c