### PR TITLE
Expose public auth login and seed dev access

### DIFF
--- a/backend/db/migrations/20251015_seed_dev_user.sql
+++ b/backend/db/migrations/20251015_seed_dev_user.sql
@@ -1,0 +1,21 @@
+-- Seed de organização e usuário de desenvolvimento
+
+-- ORG
+INSERT INTO organizations (id, name)
+SELECT '8f181879-2f22-4831-967a-31c892f271bb', 'CresceJá DEV'
+WHERE NOT EXISTS (
+  SELECT 1 FROM organizations WHERE id = '8f181879-2f22-4831-967a-31c892f271bb'
+);
+
+-- USER (senha: admin123)
+INSERT INTO users (id, email, password_hash, name, org_id, roles)
+SELECT
+  'cdbdc333-87d6-4dda-9726-a77f20609b75',
+  'rodrigooidr@hotmail.com',
+  '$2b$10$5xw1u5vGg6Kc2w3hO7jZae4F9a4mB1Q2mO0m3vV2a0b9b3l5uQH1W',
+  'Rodrigo Oliveira',
+  '8f181879-2f22-4831-967a-31c892f271bb',
+  ARRAY['OrgOwner','SuperAdmin']
+WHERE NOT EXISTS (
+  SELECT 1 FROM users WHERE email = 'rodrigooidr@hotmail.com'
+);

--- a/backend/scripts/smoke.js
+++ b/backend/scripts/smoke.js
@@ -1,7 +1,7 @@
 // backend/scripts/smoke.js
 const base = process.env.BASE_URL || 'http://localhost:4000';
 const adminEmail = process.env.SMOKE_EMAIL || 'rodrigooidr@hotmail.com';
-const adminPass = process.env.SMOKE_PASS || 'R0drig01!';
+const adminPass = process.env.SMOKE_PASS || 'admin123';
 
 async function hit(path, opts={}){
   const r = await fetch(base + path, Object.assign({ headers: { 'Content-Type':'application/json' }}, opts));
@@ -18,7 +18,7 @@ async function hit(path, opts={}){
   console.log('readyz:', r.status, r.json);
   ok &&= r.status === 200 && r.json.ok;
 
-  const l = await hit('/api/auth/login', { method: 'POST', body: JSON.stringify({ email: adminEmail, password: adminPass })});
+  const l = await hit('/auth/login', { method: 'POST', body: JSON.stringify({ email: adminEmail, password: adminPass })});
   console.log('login:', l.status, l.json && { user: l.json.user, token: l.json.token ? '***' : null });
   ok &&= l.status === 200 && !!l.json?.token;
 

--- a/backend/scripts/smoke_inbox_ws_notify.js
+++ b/backend/scripts/smoke_inbox_ws_notify.js
@@ -5,16 +5,16 @@ import pg from 'pg';
 const BASE_URL = process.env.BASE_URL || 'http://localhost:4000';
 const DB_URL = process.env.DATABASE_URL || 'postgres://cresceja:cresceja123@localhost:5432/cresceja_db';
 const ADMIN_EMAIL = process.env.SMOKE_EMAIL || 'rodrigooidr@hotmail.com';
-const ADMIN_PASS = process.env.SMOKE_PASS || 'R0drig01!';
+const ADMIN_PASS = process.env.SMOKE_PASS || 'admin123';
 
 (async () => {
   const db = new pg.Client({ connectionString: DB_URL });
   await db.connect();
 
-  const login = await axios.post(`${BASE_URL}/api/auth/login`, { email: ADMIN_EMAIL, password: ADMIN_PASS });
+  const login = await axios.post(`${BASE_URL}/auth/login`, { email: ADMIN_EMAIL, password: ADMIN_PASS });
   const token = login.data?.token;
   if (!token) throw new Error('login_failed');
-  const orgId = login.data.user?.org_id;
+  const orgId = login.data?.org?.id;
 
   const conv = await db.query(`SELECT id FROM conversations WHERE org_id=$1 LIMIT 1`, [orgId]);
   if (!conv.rows[0]) throw new Error('no_conversation');

--- a/backend/server.js
+++ b/backend/server.js
@@ -177,6 +177,15 @@ function configureApp() {
   app.set('trust proxy', 1);
   app.disable('x-powered-by');
 
+  // Limpa cabeçalhos de impersonação e evita side-effects em rotas públicas de auth
+  app.use((req, _res, next) => {
+    if (req.path && req.path.startsWith('/auth/')) {
+      delete req.headers['x-impersonate-org-id'];
+      delete req.headers['X-Impersonate-Org-Id'];
+    }
+    next();
+  });
+
   // ---------- CORS (sempre antes de qualquer rota/middleware que lide com body) ----------
   const corsOriginConfig = ALLOWED_ORIGINS.length <= 1 ? ALLOWED_ORIGINS[0] ?? false : ALLOWED_ORIGINS;
   app.use(
@@ -237,6 +246,7 @@ function configureApp() {
 
   // ---------- Rotas públicas ----------
   app.use('/api/public', publicRouter);
+  app.use('/auth', authRouter);
   app.use('/api/auth', authRouter);
   app.use(authGoogleRouter);
   app.use(authFacebookRouter);


### PR DESCRIPTION
## Summary
- strip impersonation headers from /auth requests and keep the auth router public
- tighten impersonation guarding to only run after authentication and overhaul the login flow with clearer responses plus a seeded dev user
- persist auth token and org selection on the frontend while aligning tests and smoke scripts with the new login endpoint

## Testing
- npm --prefix backend test -- --runInBand *(fails: cross-env not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd57908da883279393975048fdb879