### PR TITLE
Ensure apiUrl is consistently a string for tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,9 +77,11 @@
       "<rootDir>/src/test/jest.env.js"
     ],
     "moduleNameMapper": {
+      "^@/api$": "<rootDir>/src/api/index.js",
       "^@/(.*)$": "<rootDir>/src/$1",
       "\\.(css|less|sass|scss)$": "<rootDir>/src/test/__mocks__/styleMock.js",
-      "\\.(png|jpg|jpeg|gif|svg|webp|avif|mp4|mp3|woff|woff2)$": "<rootDir>/src/test/__mocks__/fileMock.js"
+      "\\.(png|jpg|jpeg|gif|svg|webp|avif|mp4|mp3|woff|woff2)$": "<rootDir>/src/test/__mocks__/fileMock.js",
+      "^axios$": "axios/dist/node/axios.cjs"
     }
   },
   "browserslist": {

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,2 +1,12 @@
-import inboxApi from './inboxApi.js';
+// Reexporta o client e garante um alias de apiUrl compatível
+import inboxApi, { API_BASE_URL } from './inboxApi';
+
+// SEMPRE string (evita falhas em apiUrl.replace(...) nos testes)
+export const apiUrl = typeof API_BASE_URL === 'string' ? API_BASE_URL : String(API_BASE_URL || '');
+
+// Reexports usuais
+export { default as inboxApi } from './inboxApi';
+export * from './inboxApi';
+
+// Default opcional (se algum teste fizer import default de '@/api')
 export default inboxApi;

--- a/frontend/src/inbox/normalizeMessage.js
+++ b/frontend/src/inbox/normalizeMessage.js
@@ -1,8 +1,9 @@
 // src/inbox/normalizeMessage.js
 import { normalizeDirection, isMineMessage } from './message.helpers';
-import { apiUrl } from '../api/inboxApi.js';
+import { apiUrl as inboxApiUrl } from '@/api';
 
-const API_BASE = (apiUrl || '').replace(/\/$/, '');
+const normalizedApiUrl = typeof inboxApiUrl === 'string' ? inboxApiUrl : String(inboxApiUrl || '');
+const API_BASE = normalizedApiUrl.replace(/\/$/, '');
 
 function mediaEndpoint(messageId, index) {
   const encodedId = encodeURIComponent(String(messageId || ''));


### PR DESCRIPTION
## Summary
- add an API barrel that re-exports the inbox client and guarantees a string `apiUrl`
- map Jest imports for `@/api` and force axios to use the CommonJS bundle
- update the inbox message normalizer to consume the barrel export safely

## Testing
- CI=true npm test -- --watch=false *(fails: EventSource/IntersectionObserver not defined in jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68dd63cd150483278f9afacfd4588236