### PR TITLE
Fix CRA proxy and relax dev stubs

### DIFF
--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,10 +1,14 @@
+// use SOMENTE caminhos de API — nunca "/"
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-module.exports = function(app) {
-  app.use('/api',
-    createProxyMiddleware({ target: 'http://localhost:4000', changeOrigin: true })
-  );
-  app.use('/socket.io',
-    createProxyMiddleware({ target: 'http://localhost:4000', ws: true, changeOrigin: true })
+module.exports = function (app) {
+  app.use(
+    ['/api', '/auth'], // <— apenas rotas de backend
+    createProxyMiddleware({
+      target: 'http://localhost:4000',
+      changeOrigin: true,
+      ws: false, // não proxie /ws do dev-server
+      logLevel: 'warn',
+    })
   );
 };


### PR DESCRIPTION
## Summary
- update CRA proxy to only forward API/auth routes and disable websocket proxying
- ensure debug network monkey patches add auth headers and rewrite SSE URLs consistently
- relax backend dev stubs to accept tokens via query params and return 200s for AI and alerts endpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6bc24b6c832784591c2adf7fec3a