### PR TITLE
fix: normalize token handling for auth flows

### DIFF
--- a/backend/middleware/_token.js
+++ b/backend/middleware/_token.js
@@ -1,19 +1,18 @@
-// backend/middleware/_token.js (ESM)
+// ESM
 export function extractBearerToken(req) {
-  // 1) header Authorization
+  // 1) Authorization (normalizar vírgulas/dúplicas)
   let raw = req.headers?.authorization || req.headers?.Authorization || '';
   if (typeof raw === 'string' && raw.includes(',')) {
-    // alguns navegadores/axios colam mais de um header — pega o primeiro
-    raw = raw.split(',')[0];
+    raw = raw.split(',')[0]; // pega o primeiro "Bearer ..."
   }
-  let m = /^Bearer\s+(.+)$/i.exec(raw || '');
+  const m = /^Bearer\s+(.+)$/i.exec(raw || '');
   if (m && m[1]) return m[1].trim();
 
-  // 2) query ?access_token=
+  // 2) Query (?access_token= ou ?token=) — usado por SSE/EventSource
   const q = req.query?.access_token || req.query?.token;
   if (typeof q === 'string' && q.length > 10) return q.trim();
 
-  // 3) cookie (opcional, se você usar)
+  // 3) Cookie (se algum dia usar)
   const c = req.cookies?.access_token;
   if (typeof c === 'string' && c.length > 10) return c.trim();
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -92,9 +92,12 @@ app.use((err, req, res, _next) => {
 let io;
 function authFromToken(token) {
   if (!token) return null;
+  if (typeof token === 'string' && token.includes(',')) {
+    token = token.split(',')[0];
+  }
   try {
     const secret = process.env.JWT_SECRET || 'dev_secret';
-    return jwt.verify(token.replace(/^Bearer\s+/i, ''), secret);
+    return jwt.verify(String(token || '').replace(/^Bearer\s+/i, '').trim(), secret);
   } catch {
     return null;
   }

--- a/frontend/src/api/inboxApi.js
+++ b/frontend/src/api/inboxApi.js
@@ -147,14 +147,6 @@ function log(...args) {
 
 // ===== Boot headers (token/org) =====
 try {
-  const bootToken = typeof window !== "undefined" ? localStorage.getItem("token") : null;
-  if (bootToken) {
-    inboxApi.defaults.headers.common.Authorization = `Bearer ${bootToken}`;
-    axios.defaults.headers.common.Authorization = `Bearer ${bootToken}`;
-  }
-} catch {}
-
-try {
   const savedOrg =
     typeof window !== "undefined"
       ? localStorage.getItem("activeOrgId") ?? localStorage.getItem("active_org_id")
@@ -321,11 +313,13 @@ export function setAuthToken(token) {
   try {
     if (token) {
       localStorage.setItem("token", token);
-      inboxApi.defaults.headers.common.Authorization = `Bearer ${token}`;
-      axios.defaults.headers.common.Authorization = `Bearer ${token}`;
     } else {
       localStorage.removeItem("token");
+    }
+    if (inboxApi?.defaults?.headers?.common) {
       delete inboxApi.defaults.headers.common.Authorization;
+    }
+    if (axios?.defaults?.headers?.common) {
       delete axios.defaults.headers.common.Authorization;
     }
   } catch {}

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -1,5 +1,5 @@
 // src/services/auth.js
-import inboxApi, { setActiveOrg } from "../../api/inboxApi";
+import inboxApi, { setActiveOrg, setAuthToken } from "../../api/inboxApi";
 
 
 export async function login(email, password) {
@@ -7,8 +7,7 @@ export async function login(email, password) {
   const { token, user, org, roles } = data || {};
   if (!token) throw new Error("Login sem token.");
 
-  localStorage.setItem("token", token);
-  inboxApi.defaults.headers.common.Authorization = `Bearer ${token}`;
+  setAuthToken(token);
 
   const orgId = org?.id ?? null;
   if (orgId) {
@@ -31,9 +30,8 @@ export async function login(email, password) {
 }
 
 export function logout() {
-  localStorage.removeItem("token");
+  setAuthToken(null);
   localStorage.removeItem("user");
-  delete inboxApi.defaults.headers.common.Authorization;
 }
 
 


### PR DESCRIPTION
## Summary
- normalize bearer token extraction to support duplicate headers, query tokens, and cookies
- trim bearer tokens in Socket.IO auth to avoid failures when browsers send duplicates
- ensure axios clients only set Authorization via the interceptor and update auth helpers accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded83d2cd4832797cbca770ddcd499