### PR TITLE
feat: auto-create default org and stub inbox templates

### DIFF
--- a/backend/middleware/withOrg.js
+++ b/backend/middleware/withOrg.js
@@ -1,12 +1,23 @@
 import { pool } from '#db';
 import { isUuid } from '../utils/isUuid.js';
 
-export async function withOrg(req, res, next) {
+// Middleware leve: apenas garante que req.orgId seja definido caso exista no token/req
+export function withOrg(req, _res, next) {
+  const orgId = req.user?.org_id || req.user?.orgId || req.orgId;
+  if (orgId) req.orgId = orgId;
+  next();
+}
+
+// Middleware completo usado nas rotas que precisam de escopo/org + conexão pg
+export async function withOrgScope(req, res, next) {
   try {
+    withOrg(req, res, () => {});
+
     const user = req.user || {};
-    let orgId = user.org_id;
+    let orgId = req.orgId;
     if (user.is_superadmin && req.headers['x-impersonate-org']) {
       orgId = req.headers['x-impersonate-org'];
+      req.orgId = orgId;
     }
     if (!isUuid(orgId)) {
       return res.status(400).json({ error: 'org_required' });
@@ -38,7 +49,9 @@ export async function withOrg(req, res, next) {
       res.once('close', () => cleanup('rollback'));
       next();
     } catch (e) {
-      try { await client.query('ROLLBACK'); } catch {}
+      try {
+        await client.query('ROLLBACK');
+      } catch {}
       client.release();
       next(e);
     }
@@ -46,3 +59,5 @@ export async function withOrg(req, res, next) {
     next(err);
   }
 }
+
+export default withOrgScope;

--- a/backend/routes/activities.js
+++ b/backend/routes/activities.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { authRequired } from '../middleware/auth.js';
-import { withOrg } from '../middleware/withOrg.js';
+import { withOrgScope } from '../middleware/withOrg.js';
 import { requireRole, ROLES } from '../middleware/requireRole.js';
 import * as ctrl from '../controllers/activitiesController.js';
 
@@ -8,7 +8,7 @@ const router = Router();
 
 const AGENT_ROLES = [ROLES.OrgAgent, ROLES.OrgAdmin, ROLES.OrgOwner, ROLES.SuperAdmin];
 
-router.use(authRequired, withOrg, requireRole(AGENT_ROLES));
+router.use(authRequired, withOrgScope, requireRole(AGENT_ROLES));
 
 router.get('/calendars', ctrl.listCalendars);
 router.post('/calendars', ctrl.createCalendar);

--- a/backend/routes/calendar.js
+++ b/backend/routes/calendar.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { authRequired } from '../middleware/auth.js';
-import { withOrg } from '../middleware/withOrg.js';
+import { withOrgScope } from '../middleware/withOrg.js';
 import { requireRole, ROLES } from '../middleware/requireRole.js';
 import * as ctrl from '../controllers/calendarController.js';
 
@@ -8,7 +8,7 @@ const router = Router();
 
 const AGENT_ROLES = [ROLES.OrgAgent, ROLES.OrgAdmin, ROLES.OrgOwner, ROLES.SuperAdmin];
 
-router.use(authRequired, withOrg, requireRole(AGENT_ROLES));
+router.use(authRequired, withOrgScope, requireRole(AGENT_ROLES));
 
 router.get('/', ctrl.listCalendars);
 router.post('/', ctrl.createCalendar);

--- a/backend/routes/content.js
+++ b/backend/routes/content.js
@@ -8,14 +8,14 @@ import {
   updatePost,
 } from '../controllers/contentController.js';
 import { authRequired } from '../middleware/auth.js';
-import { withOrg } from '../middleware/withOrg.js';
+import { withOrgScope } from '../middleware/withOrg.js';
 import { requireRole, ROLES } from '../middleware/requireRole.js';
 
 const router = Router();
 
 const AGENT_ROLES = [ROLES.OrgAgent, ROLES.OrgAdmin, ROLES.OrgOwner, ROLES.SuperAdmin];
 
-router.use(authRequired, withOrg, requireRole(AGENT_ROLES));
+router.use(authRequired, withOrgScope, requireRole(AGENT_ROLES));
 
 router.get('/assets', listAssets);
 router.post('/assets', createAsset);

--- a/backend/routes/inbox.templates.js
+++ b/backend/routes/inbox.templates.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { authRequired } from '../middleware/auth.js';
+import { withOrg } from '../middleware/withOrg.js';
+
+const router = Router();
+router.use(authRequired, withOrg);
+
+router.get('/templates', (_req, res) => res.json({ items: [] }));
+router.get('/quick-replies', (_req, res) => res.json({ items: [] }));
+
+export default router;

--- a/backend/routes/integrations/meta.oauth.js
+++ b/backend/routes/integrations/meta.oauth.js
@@ -1,10 +1,10 @@
 import { Router } from 'express';
 import { authRequired } from '../../middleware/auth.js';
-import { withOrg } from '../../middleware/withOrg.js';
+import { withOrgScope } from '../../middleware/withOrg.js';
 import { pool } from '#db';
 
 const router = Router();
-router.use(authRequired, withOrg);
+router.use(authRequired, withOrgScope);
 
 // Stub que guarda token de usuário da Meta (NÃO seguro para produção)
 router.post('/connect', async (req, res, next) => {

--- a/backend/routes/leads.js
+++ b/backend/routes/leads.js
@@ -6,14 +6,14 @@ import {
   moverParaOportunidade,
 } from '../controllers/leadsController.js';
 import { authRequired } from '../middleware/auth.js';
-import { withOrg } from '../middleware/withOrg.js';
+import { withOrgScope } from '../middleware/withOrg.js';
 import { requireRole, ROLES } from '../middleware/requireRole.js';
 
 const AGENT_ROLES = [ROLES.OrgAgent, ROLES.OrgAdmin, ROLES.OrgOwner, ROLES.SuperAdmin];
 
 const router = Router();
 
-router.use(authRequired, withOrg, requireRole(AGENT_ROLES));
+router.use(authRequired, withOrgScope, requireRole(AGENT_ROLES));
 
 router.get('/', list);
 router.post('/', create);

--- a/backend/routes/marketing.js
+++ b/backend/routes/marketing.js
@@ -22,7 +22,7 @@ import {
   updateAutomationStatus,
 } from '../controllers/marketingController.js';
 import { authRequired } from '../middleware/auth.js';
-import { withOrg } from '../middleware/withOrg.js';
+import { withOrgScope } from '../middleware/withOrg.js';
 import { requireRole, ROLES } from '../middleware/requireRole.js';
 
 const router = Router();
@@ -30,7 +30,7 @@ const router = Router();
 const MARKETING_AGENT_ROLES = [ROLES.OrgAgent, ROLES.OrgAdmin, ROLES.OrgOwner, ROLES.SuperAdmin];
 const MARKETING_MANAGER_ROLES = [ROLES.OrgAdmin, ROLES.OrgOwner, ROLES.SuperAdmin];
 
-router.use(authRequired, withOrg, requireRole(MARKETING_AGENT_ROLES));
+router.use(authRequired, withOrgScope, requireRole(MARKETING_AGENT_ROLES));
 
 router.get('/lists', listLists);
 router.post('/lists', createList);

--- a/backend/routes/onboarding.js
+++ b/backend/routes/onboarding.js
@@ -1,13 +1,13 @@
 import { Router } from 'express';
 import { authRequired } from '../middleware/auth.js';
-import { withOrg } from '../middleware/withOrg.js';
+import { withOrgScope } from '../middleware/withOrg.js';
 import { requireRole, ROLES } from '../middleware/requireRole.js';
 
 const router = Router();
 
 const AGENT_ROLES = [ROLES.OrgAgent, ROLES.OrgAdmin, ROLES.OrgOwner, ROLES.SuperAdmin];
 
-router.use(authRequired, withOrg, requireRole(AGENT_ROLES));
+router.use(authRequired, withOrgScope, requireRole(AGENT_ROLES));
 
 // Converte oportunidade em cliente e inicia tarefas de onboarding
 router.put('/opportunities/:id/converter', async (req, res, next) => {

--- a/backend/routes/opportunities.js
+++ b/backend/routes/opportunities.js
@@ -1,14 +1,14 @@
 import { Router } from 'express';
 import { board, create, update } from '../controllers/opportunitiesController.js';
 import { authRequired } from '../middleware/auth.js';
-import { withOrg } from '../middleware/withOrg.js';
+import { withOrgScope } from '../middleware/withOrg.js';
 import { requireRole, ROLES } from '../middleware/requireRole.js';
 
 const router = Router();
 
 const AGENT_ROLES = [ROLES.OrgAgent, ROLES.OrgAdmin, ROLES.OrgOwner, ROLES.SuperAdmin];
 
-router.use(authRequired, withOrg, requireRole(AGENT_ROLES));
+router.use(authRequired, withOrgScope, requireRole(AGENT_ROLES));
 
 router.get('/board', board);
 router.post('/', create);

--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -3,7 +3,7 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { randomUUID } from 'crypto';
-import { withOrg } from '../middleware/withOrg.js';
+import { withOrgScope } from '../middleware/withOrg.js';
 import { authRequired } from '../middleware/auth.js';
 import { pool } from '#db';
 
@@ -13,7 +13,7 @@ fs.mkdirSync(uploadDir, { recursive: true });
 
 const upload = multer({ dest: uploadDir });
 
-router.use(authRequired, withOrg);
+router.use(authRequired, withOrgScope);
 
 // Upload local simples, retorna URL relativa /uploads/<file>
 router.post('/', upload.single('file'), async (req, res, next) => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,9 @@ import aiCompatRouter from './routes/ai.compat.js';
 import telemetryRouter from './routes/telemetry.js';
 import uploadsRouter from './routes/uploads.js';
 import webhooksMetaPages from './routes/webhooks/meta.pages.js';
+import organizationsRouter from './routes/organizations.js';
+import inboxTemplatesRouter from './routes/inbox.templates.js';
+import debugRouter from './routes/debug.js';
 // Adicione outras rotas **existentes** se necessário.
 
 // Util
@@ -64,6 +67,8 @@ app.use('/api/public', publicRouter);
 app.use('/api/content', contentRouter);
 app.use('/api/telemetry', telemetryRouter);
 app.use('/api/uploads', uploadsRouter);
+app.use('/api/orgs', organizationsRouter);
+app.use('/api/inbox', inboxTemplatesRouter);
 
 // Webhooks
 app.use('/api/webhooks/meta/pages', webhooksMetaPages);
@@ -72,6 +77,10 @@ app.use('/api/webhooks/meta/pages', webhooksMetaPages);
 app.use('/api/inbox', inboxCompatRouter);
 app.use('/api/crm', crmCompatRouter);
 app.use('/api/ai', aiCompatRouter);
+
+if (process.env.NODE_ENV !== 'production') {
+  app.use('/api/debug', debugRouter);
+}
 
 // Static (se houver build do frontend)
 const clientDir = path.join(__dirname, '..', 'frontend', 'build');


### PR DESCRIPTION
## Summary
- add a lightweight withOrg helper alongside the existing scoped middleware
- ensure GET /api/orgs/me seeds dev tables and returns a default organization payload
- expose inbox template/quick-reply stubs and a /api/debug/whoami helper while wiring the routes into the server

## Testing
- npm run test:backend -- --runInBand *(fails: `cross-env` not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68deda2adf808327a1d70ee3eae04ef2