### PR TITLE
feat: add inbox alerts SSE stream and update test scripts

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -22,7 +22,7 @@ export function auth(req, res, next) {
     if (!token) {
       return res
         .status(401)
-        .json({ error: "invalid_token", message: "invalid token" });
+        .json({ error: "missing_token", message: "missing token" });
     }
     const secret = process.env.JWT_SECRET || "dev_secret";
     const payload = jwt.verify(token, secret);

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "db:migrate": "node ./scripts/migrate.js",
     "start": "node server.js",
     "dev": "nodemon --watch . --ext js,mjs server.js",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --config ./jest.config.mjs --runInBand",
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --config ./jest.config.mjs --runInBand",
     "test:watch": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --config ./jest.config.mjs --watch",
     "migrate:test": "node backend/test/utils/runMigrations.mjs",
     "test:int": "cross-env RUN_INT_TESTS=true jest --runInBand",

--- a/backend/routes/inbox.alerts.js
+++ b/backend/routes/inbox.alerts.js
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { authRequired } from '../middleware/auth.js';
+import { withOrg } from '../middleware/withOrg.js';
+
+const router = Router();
+
+// GET /api/inbox/alerts/stream?access_token=...
+router.get('/alerts/stream', authRequired, withOrg, (req, res) => {
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+    Connection: 'keep-alive',
+  });
+  res.flushHeaders?.();
+
+  const send = (event, data) => {
+    res.write(`event: ${event}\n`);
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+
+  send('ready', { ok: true, orgId: req.orgId || null });
+
+  const hb = setInterval(() => {
+    res.write(': hb\n\n');
+  }, 15000);
+
+  req.on('close', () => {
+    clearInterval(hb);
+    try {
+      res.end();
+    } catch (err) {
+      // noop
+    }
+  });
+});
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -26,6 +26,7 @@ import uploadsRouter from './routes/uploads.js';
 import webhooksMetaPages from './routes/webhooks/meta.pages.js';
 import organizationsRouter from './routes/organizations.js';
 import inboxTemplatesRouter from './routes/inbox.templates.js';
+import inboxAlertsRouter from './routes/inbox.alerts.js';
 import debugRouter from './routes/debug.js';
 // Adicione outras rotas **existentes** se necessário.
 
@@ -68,6 +69,7 @@ app.use('/api/content', contentRouter);
 app.use('/api/telemetry', telemetryRouter);
 app.use('/api/uploads', uploadsRouter);
 app.use('/api/orgs', organizationsRouter);
+app.use('/api/inbox', inboxAlertsRouter);
 app.use('/api/inbox', inboxTemplatesRouter);
 
 // Webhooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       ],
       "devDependencies": {
         "concurrently": "^9.1.0",
-        "cross-env": "^10.0.0",
+        "cross-env": "^10.1.0",
+        "cross-env-shell": "^7.0.3",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0"
       }
@@ -22565,9 +22566,9 @@
       "link": true
     },
     "node_modules/cross-env": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
-      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22580,6 +22581,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/cross-env-shell": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env-shell/-/cross-env-shell-7.0.3.tgz",
+      "integrity": "sha512-ZEtnHInQRRzuAbmMpUqu/mk1jaZun14WdcmnpzZZ6Bpi1BLTPkbKioQ6+wkFssf+m/DpdttDpsCX6g8zU9W40A==",
+      "dev": true,
+      "license": "UNLICENSED",
+      "bin": {
+        "cross-env-shell": "wrapper.sh"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "test:backend": "npm --prefix backend test",
+    "test:backend": "cross-env-shell NODE_OPTIONS=--experimental-vm-modules npm --prefix backend run test",
     "test:backend:watch": "npm --prefix backend run test:watch",
-    "test:frontend": "npm --prefix frontend test",
-    "test": "npm run test:backend && npm run test:frontend",
+    "test:frontend": "npm --prefix frontend run test",
+    "test:all": "npm run test:backend && CI=1 npm run test:frontend",
+    "test": "npm run test:all",
     "test:frontend:orgai": "npx jest --config frontend/jest.orgai.cjs --runInBand",
     "test:orgai": "npm run test:backend && npm run test:frontend:orgai",
     "dev:backend": "npm --prefix backend run dev",
@@ -35,7 +36,8 @@
   },
   "devDependencies": {
     "concurrently": "^9.1.0",
-    "cross-env": "^10.0.0",
+    "cross-env": "^10.1.0",
+    "cross-env-shell": "^7.0.3",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0"
   },


### PR DESCRIPTION
## Summary
- add cross-env-shell powered test scripts at the workspace root and set backend tests to run with NODE_ENV=test
- expose an authenticated /api/inbox/alerts/stream SSE route with heartbeat support and hook it into the Express server
- ensure missing bearer tokens surface a dedicated missing_token error for auth middleware consumers

## Testing
- npm run test:backend -- --runInBand
- CI=1 npm run test:frontend *(fails: existing suites rely on a fully mocked inbox UI environment and several cases break under jsdom without additional setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dedcb925d8832784a77d23e5289a6f