### PR TITLE
Align JWT defaults and improve token handling

### DIFF
--- a/backend/.env.docker
+++ b/backend/.env.docker
@@ -18,7 +18,7 @@ PORT=4000
 CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
 # JWT
-JWT_SECRET=CresceJa_jwt123
+JWT_SECRET=dev-change-me
 
 # Ambiente / Logs
 NODE_ENV=production

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -26,7 +26,7 @@ export function auth(req, res, next) {
         .status(401)
         .json({ error: "missing_token", message: "missing token" });
     }
-    const secret = process.env.JWT_SECRET || "dev_secret";
+    const secret = process.env.JWT_SECRET || "dev-change-me";
     let payload;
 
     try {

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -16,7 +16,7 @@ function resolveQuery(req) {
 }
 
 function signToken(payload) {
-  const secret = process.env.JWT_SECRET || 'dev';
+  const secret = process.env.JWT_SECRET || 'dev-change-me';
   const expiresIn = process.env.JWT_EXPIRES_IN || '12h';
   return jwt.sign(payload, secret, { expiresIn });
 }

--- a/backend/routes/subscription.js
+++ b/backend/routes/subscription.js
@@ -6,7 +6,7 @@ import { getClientByUserId, computeDaysRemaining, isExpired } from "../lib/subsc
 import * as Auth from "../middleware/auth.js";
 
 const router = express.Router();
-const JWT_SECRET = process.env.JWT_SECRET || "segredo";
+const JWT_SECRET = process.env.JWT_SECRET || "dev-change-me";
 
 // Fallback simples de autenticação via Bearer caso o middleware não exponha `auth`
 function fallbackAuth(req, res, next) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -109,7 +109,7 @@ function authFromToken(token) {
     token = token.split(',')[0];
   }
   try {
-    const secret = process.env.JWT_SECRET || 'dev_secret';
+    const secret = process.env.JWT_SECRET || 'dev-change-me';
     return jwt.verify(String(token || '').replace(/^Bearer\s+/i, '').trim(), secret);
   } catch {
     return null;

--- a/frontend/src/api/inboxApi.js
+++ b/frontend/src/api/inboxApi.js
@@ -106,21 +106,17 @@ function pathOnly(u) {
 // ===== Auth/Org headers helpers =====
 function ensureAuthHeader(config) {
   try {
-    const token = typeof window !== "undefined" ? localStorage.getItem("token") : null;
-    if (token) {
-      const current = String(
-        (config.headers && (config.headers.Authorization || config.headers.authorization)) ||
-          ""
-      );
-      if (!/^Bearer\s+/i.test(current)) {
-        config.headers = { ...(config.headers || {}), Authorization: `Bearer ${token}` };
-      }
-      if (
-        typeof config.headers.Authorization === "string" &&
-        config.headers.Authorization.includes(",")
-      ) {
-        config.headers.Authorization = config.headers.Authorization.split(",")[0];
-      }
+    const t = typeof window !== "undefined" ? localStorage.getItem("token") : null;
+    if (!t) return config;
+    const existing = (
+      config.headers?.Authorization || config.headers?.authorization || ""
+    ).trim();
+    if (!existing) {
+      setHeader(config, "Authorization", `Bearer ${t}`);
+    } else {
+      const first = existing.split(",")[0].trim();
+      setHeader(config, "Authorization", first);
+      if (config.headers?.authorization) delete config.headers.authorization;
     }
   } catch {}
   return config;

--- a/frontend/src/pages/inbox/hooks/useInboxAlerts.js
+++ b/frontend/src/pages/inbox/hooks/useInboxAlerts.js
@@ -68,9 +68,9 @@ export function useInboxAlerts() {
   // SSE stream
   useEffect(() => {
     if (typeof EventSource !== 'function') return () => {};
-    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : '';
+    const t = typeof window !== 'undefined' ? localStorage.getItem('token') || '' : '';
     const base = String(apiUrl || '').replace(/\/$/, '');
-    const url = `${base}/inbox/alerts/stream?access_token=${encodeURIComponent(token || '')}`;
+    const url = `${base}/inbox/alerts/stream?access_token=${encodeURIComponent(t)}`;
     const es = new EventSource(url, { withCredentials: true });
     esRef.current = es;
     es.addEventListener('alert', (ev) => {

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -8,6 +8,7 @@ export async function login(email, password) {
   if (!token) throw new Error("Login sem token.");
 
   setAuthToken(token);
+  // não fixe no default; o interceptor já injeta por requisição
 
   const orgId = org?.id ?? null;
   if (orgId) {


### PR DESCRIPTION
## Summary
- unify the JWT secret fallback across middleware, routes, sockets and docker env
- allow subscription fallback auth to respect the shared default secret
- propagate inbox SSE token via query string and harden axios auth header management
- document reliance on interceptors instead of default headers during login

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df01f01d408327a62ec45350b02312