### PR TITLE
Align JWT secret configuration and diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ backend/.nyc_output/
 # Env files
 backend/.env
 backend/.env.*    # ex: .env.local, .env.development, .env.docker
+!backend/.env
+!backend/.env.docker
 
 # ========================================
 # Frontend / React

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,2 @@
+JWT_SECRET=dev-change-me
+NODE_ENV=development

--- a/backend/.env.docker
+++ b/backend/.env.docker
@@ -21,7 +21,7 @@ CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 JWT_SECRET=dev-change-me
 
 # Ambiente / Logs
-NODE_ENV=production
+NODE_ENV=development
 LOG_LEVEL=info
 
 # Worker (BullMQ)

--- a/backend/server.js
+++ b/backend/server.js
@@ -38,6 +38,10 @@ const __dirname = path.dirname(__filename);
 
 // App
 const app = express();
+if (process.env.NODE_ENV !== 'production') {
+  const mask = (s) => (s ? String(s).slice(0, 3) + '***' : '(unset)');
+  console.log('[BOOT] NODE_ENV=', process.env.NODE_ENV, ' JWT_SECRET=', mask(process.env.JWT_SECRET));
+}
 const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
 
 app.use(express.json({ limit: '10mb' }));

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -42,7 +42,8 @@ services:
     env_file:
       - ../backend/.env.docker         # defina DATABASE_URL e REDIS_URL aqui
     environment:
-      NODE_ENV: production
+      NODE_ENV: development
+      JWT_SECRET: dev-change-me
       PORT: "4000"
       # Se o backend faz CORS, mantenha as origins separadas por vírgula
       CORS_ORIGINS: http://localhost:3000,http://127.0.0.1:3000
@@ -66,7 +67,8 @@ services:
     env_file:
       - ../backend/.env.docker
     environment:
-      NODE_ENV: production
+      NODE_ENV: development
+      JWT_SECRET: dev-change-me
     depends_on:
       postgres:
         condition: service_healthy
@@ -83,7 +85,8 @@ services:
     env_file:
       - ../backend/.env.docker
     environment:
-      NODE_ENV: production
+      NODE_ENV: development
+      JWT_SECRET: dev-change-me
     depends_on:
       postgres:
         condition: service_healthy
@@ -100,7 +103,8 @@ services:
     env_file:
       - ../backend/.env.docker
     environment:
-      NODE_ENV: production
+      NODE_ENV: development
+      JWT_SECRET: dev-change-me
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- ensure the backend env files document the dev JWT secret and development mode defaults
- add a boot-time diagnostic log for JWT configuration when running outside production
- align docker-compose services with the shared development JWT secret

## Testing
- npm test -- --watchAll=false *(fails: existing frontend inbox cache tests in jest)*

------
https://chatgpt.com/codex/tasks/task_e_68df0ed0aa348327aa374be4b508be7b