### PR TITLE
Ensure auth headers propagate and dev inbox stubs

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -20,14 +20,25 @@ const isProd = String(process.env.NODE_ENV) === 'production';
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-only-secret';
 
 function getToken(req) {
-  const bearer = extractBearer(req);
-  if (bearer) return bearer;
+  const header = req.headers?.authorization ?? req.headers?.Authorization;
+  if (typeof header === 'string' && header) {
+    const first = header.split(',')[0]?.trim() ?? '';
+    if (/^Bearer\s+/i.test(first)) {
+      const cleaned = first.replace(/^Bearer\s+/i, '').trim();
+      if (cleaned) return cleaned;
+    }
+  }
 
-  if (req.query?.access_token) {
+  if (req.query?.access_token != null) {
     return String(req.query.access_token);
   }
 
-  return null;
+  if (req.cookies?.access_token != null) {
+    return String(req.cookies.access_token);
+  }
+
+  const bearer = extractBearer(req);
+  return bearer || null;
 }
 
 function hydrateUser(payload = {}) {

--- a/backend/routes/inbox.settings.js
+++ b/backend/routes/inbox.settings.js
@@ -1,10 +1,21 @@
 import { Router } from 'express';
 
 const router = Router();
+const isProd = String(process.env.NODE_ENV) === 'production';
 
-router.get('/inbox/templates', (_req, res) => res.json([]));
-router.get('/inbox/quick-replies', (_req, res) => res.json([]));
+router.get('/inbox/templates', (req, res) => {
+  if (!req.org?.id && !isProd) return res.json([]);
+  return res.json([]);
+});
+router.get('/inbox/quick-replies', (req, res) => {
+  if (!req.org?.id && !isProd) return res.json([]);
+  return res.json([]);
+});
 router.get('/inbox/conversations', (req, res) => {
+  if (!req.org?.id && !isProd) {
+    const { status = 'open', limit = 50 } = req.query;
+    return res.json({ items: [], status, limit: Number(limit) });
+  }
   const { status = 'open', limit = 50 } = req.query;
   res.json({ items: [], status, limit: Number(limit) });
 });

--- a/backend/routes/orgs.features.js
+++ b/backend/routes/orgs.features.js
@@ -3,8 +3,12 @@ import { getFeatureAllowance, getUsage } from '../services/features.js';
 import { getOrgFeatures } from '../services/orgFeatures.js';
 
 const router = Router();
+const isProd = String(process.env.NODE_ENV) === 'production';
 
 router.get('/api/orgs/:id/features', async (req, res) => {
+  if (!req.org?.id && !isProd) {
+    return res.json({ feature_flags: {}, features: {} });
+  }
   const orgId = req.params.id;
   const codes = [
     'whatsapp_numbers','whatsapp_mode_baileys','whatsapp_mode_api',


### PR DESCRIPTION
## Summary
- ensure `authFetch` always injects Authorization and X-Org-Id headers, even when given a `Request`
- prioritize org ID resolution in the axios interceptor and middleware while accepting query tokens for SSE
- let dev inbox routes return stub responses instead of failing when no org is resolved

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfb763c1a88327b20a2160c4df25f5