### PR TITLE
Align admin org client with /api/orgs routes

### DIFF
--- a/frontend/frontend/src/api/__mocks__/inboxApi.js
+++ b/frontend/frontend/src/api/__mocks__/inboxApi.js
@@ -337,7 +337,7 @@ async function _get(path, config = {}) {
     }
   }
 
-  if (url === "/admin/orgs") {
+  if (url === "/orgs") {
     const status =
       config?.params?.status || searchParams.get('status') || "active";
     const q = String(
@@ -782,7 +782,7 @@ const inboxApi = {
 function callListAdminOrgs(status = "active", options = {}) {
   const cfg = { ...(options || {}) };
   cfg.params = { ...(cfg.params || {}), status };
-  return inboxApi.get(`/admin/orgs`, cfg);
+  return inboxApi.get(`/orgs`, cfg);
 }
 
 async function callAdminListOrgs(params = {}, options = {}) {
@@ -790,7 +790,7 @@ async function callAdminListOrgs(params = {}, options = {}) {
   const normalized = { status: 'active', q: '', ...(params || {}) };
   cfg.params = { ...(cfg.params || {}), status: normalized.status };
   if (normalized.q) cfg.params.q = normalized.q;
-  const response = await inboxApi.get(`/admin/orgs`, cfg);
+  const response = await inboxApi.get(`/orgs`, cfg);
   const payload = response?.data;
   const list = Array.isArray(payload?.items)
     ? payload.items
@@ -807,7 +807,7 @@ async function callAdminListOrgs(params = {}, options = {}) {
 }
 
 function callPatchAdminOrg(orgId, payload, options = {}) {
-  return inboxApi.patch(`/admin/orgs/${orgId}`, payload, options);
+  return inboxApi.patch(`/orgs/${orgId}`, payload, options);
 }
 
 function callPutAdminOrgPlan(orgId, payload, options = {}) {

--- a/frontend/frontend/src/api/__mocks__/index.js
+++ b/frontend/frontend/src/api/__mocks__/index.js
@@ -323,7 +323,7 @@ api.__mockMetaReset = __mockMetaReset;
 // === Named exports esperados por testes ===
 // Observação: eles apenas delegam para o mock default (GET/POST etc.)
 export async function searchOrgs(query = "", opts = {}) {
-  return api.get("/admin/orgs", { ...(opts || {}), params: { q: query, ...(opts?.params || {}) } });
+  return api.get("/orgs", { ...(opts || {}), params: { q: query, ...(opts?.params || {}) } });
 }
 export async function searchClients(query = "", opts = {}) {
   return api.get("/admin/clients", { ...(opts || {}), params: { q: query, ...(opts?.params || {}) } });

--- a/frontend/frontend/src/components/settings/OrgSelector.jsx
+++ b/frontend/frontend/src/components/settings/OrgSelector.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import inboxApi, { getImpersonateOrgId, setImpersonateOrgId } from 'api/inboxApi';
+import { adminListOrgs, getImpersonateOrgId, setImpersonateOrgId } from 'api/inboxApi';
 
 export default function OrgSelector({ onChanged }) {
   const [orgs, setOrgs] = useState([]);
@@ -13,15 +13,14 @@ export default function OrgSelector({ onChanged }) {
       setLoading(true);
       setError('');
       try {
-        const { data } = await inboxApi.get('/admin/orgs', {
-          params: { status: 'active' },
-          meta: { scope: 'global' },
-        });
+        const data = await adminListOrgs({ status: 'active' });
         if (!mounted) return;
         const list = Array.isArray(data?.data)
           ? data.data
           : Array.isArray(data?.items)
           ? data.items
+          : Array.isArray(data?.orgs)
+          ? data.orgs
           : Array.isArray(data)
           ? data
           : [];

--- a/frontend/frontend/src/pages/admin/AdminOrgDetails.jsx
+++ b/frontend/frontend/src/pages/admin/AdminOrgDetails.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import inboxApi from '../../api/inboxApi';
+import { getAdminOrg } from '../../api/inboxApi';
 
 const tabs = ['overview','billing','whatsapp','integrations','users','credits','logs','data'];
 
@@ -12,8 +12,8 @@ export default function AdminOrgDetails(){
   useEffect(()=>{
     (async ()=>{
       try {
-        const res = await inboxApi.get(`/admin/orgs/${id}`, { meta:{ scope:'global' }});
-        setOrg(res.data);
+        const data = await getAdminOrg(id);
+        setOrg(data);
       } catch(e){
         console.error(e);
       }

--- a/frontend/frontend/src/pages/admin/AdminOrgsList.jsx
+++ b/frontend/frontend/src/pages/admin/AdminOrgsList.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import inboxApi from '../../api/inboxApi';
+import { adminListOrgs } from '../../api/inboxApi';
 import { useOrg } from '../../contexts/OrgContext.jsx';
 import useToastFallback from '../../hooks/useToastFallback';
 
@@ -36,11 +36,13 @@ export default function AdminOrgsList() {
     setLoading(true);
     setError(false);
     try {
-      const res = await inboxApi.get('/admin/orgs', {
-        params: { q: debouncedQ, page, pageSize: 20 },
-        meta: { scope: 'global' },
-      });
-      setItems(res.data.items || []);
+      const raw = await adminListOrgs({ q: debouncedQ, page, pageSize: 20 });
+      const list =
+        Array.isArray(raw?.items) ? raw.items :
+        Array.isArray(raw?.data) ? raw.data :
+        Array.isArray(raw?.orgs) ? raw.orgs :
+        Array.isArray(raw) ? raw : [];
+      setItems(list);
     } catch (e) {
       setError(true);
       toast({ title: 'Falha ao carregar organizações' });

--- a/frontend/frontend/src/pages/admin/OrgsListPage.jsx
+++ b/frontend/frontend/src/pages/admin/OrgsListPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import inboxApi from "../../api/inboxApi";
+import { adminListOrgs } from "../../api/inboxApi";
 import useActiveOrgGate from "../../hooks/useActiveOrgGate";
 import { useOrg } from "../../contexts/OrgContext.jsx";
 
@@ -15,15 +15,11 @@ export default function OrgsListPage({ minRole = "SuperAdmin" }) {
     let alive = true;
     (async () => {
       try {
-        // Admin endpoint em ESCOPO GLOBAL (sem X-Org-Id)
-        const res = await inboxApi.get("/admin/orgs", {
-          params: { q },
-          meta: { scope: "global" },
-        });
-        const raw = res?.data;
+        const raw = await adminListOrgs({ q });
         const items =
           Array.isArray(raw?.items) ? raw.items :
           Array.isArray(raw?.orgs) ? raw.orgs :
+          Array.isArray(raw?.data) ? raw.data :
           Array.isArray(raw) ? raw : [];
         if (!alive) return;
         setState({ loading: false, items, error: null });

--- a/frontend/src/api/__mocks__/inboxApi.js
+++ b/frontend/src/api/__mocks__/inboxApi.js
@@ -337,7 +337,7 @@ async function _get(path, config = {}) {
     }
   }
 
-  if (url === "/admin/orgs") {
+  if (url === "/orgs") {
     const status =
       config?.params?.status || searchParams.get('status') || "active";
     const q = String(
@@ -782,7 +782,7 @@ const inboxApi = {
 function callListAdminOrgs(status = "active", options = {}) {
   const cfg = { ...(options || {}) };
   cfg.params = { ...(cfg.params || {}), status };
-  return inboxApi.get(`/admin/orgs`, cfg);
+  return inboxApi.get(`/orgs`, cfg);
 }
 
 async function callAdminListOrgs(params = {}, options = {}) {
@@ -790,7 +790,7 @@ async function callAdminListOrgs(params = {}, options = {}) {
   const normalized = { status: 'active', q: '', ...(params || {}) };
   cfg.params = { ...(cfg.params || {}), status: normalized.status };
   if (normalized.q) cfg.params.q = normalized.q;
-  const response = await inboxApi.get(`/admin/orgs`, cfg);
+  const response = await inboxApi.get(`/orgs`, cfg);
   const payload = response?.data;
   const list = Array.isArray(payload?.items)
     ? payload.items
@@ -807,7 +807,7 @@ async function callAdminListOrgs(params = {}, options = {}) {
 }
 
 function callPatchAdminOrg(orgId, payload, options = {}) {
-  return inboxApi.patch(`/admin/orgs/${orgId}`, payload, options);
+  return inboxApi.patch(`/orgs/${orgId}`, payload, options);
 }
 
 function callPutAdminOrgPlan(orgId, payload, options = {}) {

--- a/frontend/src/api/__mocks__/index.js
+++ b/frontend/src/api/__mocks__/index.js
@@ -323,7 +323,7 @@ api.__mockMetaReset = __mockMetaReset;
 // === Named exports esperados por testes ===
 // Observação: eles apenas delegam para o mock default (GET/POST etc.)
 export async function searchOrgs(query = "", opts = {}) {
-  return api.get("/admin/orgs", { ...(opts || {}), params: { q: query, ...(opts?.params || {}) } });
+  return api.get("/orgs", { ...(opts || {}), params: { q: query, ...(opts?.params || {}) } });
 }
 export async function searchClients(query = "", opts = {}) {
   return api.get("/admin/clients", { ...(opts || {}), params: { q: query, ...(opts?.params || {}) } });

--- a/frontend/src/components/settings/OrgSelector.jsx
+++ b/frontend/src/components/settings/OrgSelector.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import inboxApi, { getImpersonateOrgId, setImpersonateOrgId } from 'api/inboxApi';
+import { adminListOrgs, getImpersonateOrgId, setImpersonateOrgId } from 'api/inboxApi';
 
 export default function OrgSelector({ onChanged }) {
   const [orgs, setOrgs] = useState([]);
@@ -13,15 +13,14 @@ export default function OrgSelector({ onChanged }) {
       setLoading(true);
       setError('');
       try {
-        const { data } = await inboxApi.get('/admin/orgs', {
-          params: { status: 'active' },
-          meta: { scope: 'global' },
-        });
+        const data = await adminListOrgs({ status: 'active' });
         if (!mounted) return;
         const list = Array.isArray(data?.data)
           ? data.data
           : Array.isArray(data?.items)
           ? data.items
+          : Array.isArray(data?.orgs)
+          ? data.orgs
           : Array.isArray(data)
           ? data
           : [];

--- a/frontend/src/pages/admin/AdminOrgDetails.jsx
+++ b/frontend/src/pages/admin/AdminOrgDetails.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import inboxApi from '../../api/inboxApi';
+import { getAdminOrg } from '../../api/inboxApi';
 
 const tabs = ['overview','billing','whatsapp','integrations','users','credits','logs','data'];
 
@@ -12,8 +12,8 @@ export default function AdminOrgDetails(){
   useEffect(()=>{
     (async ()=>{
       try {
-        const res = await inboxApi.get(`/admin/orgs/${id}`, { meta:{ scope:'global' }});
-        setOrg(res.data);
+        const data = await getAdminOrg(id);
+        setOrg(data);
       } catch(e){
         console.error(e);
       }

--- a/frontend/src/pages/admin/AdminOrgsList.jsx
+++ b/frontend/src/pages/admin/AdminOrgsList.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import inboxApi from '../../api/inboxApi';
+import { adminListOrgs } from '../../api/inboxApi';
 import { useOrg } from '../../contexts/OrgContext.jsx';
 import useToastFallback from '../../hooks/useToastFallback';
 
@@ -36,11 +36,13 @@ export default function AdminOrgsList() {
     setLoading(true);
     setError(false);
     try {
-      const res = await inboxApi.get('/admin/orgs', {
-        params: { q: debouncedQ, page, pageSize: 20 },
-        meta: { scope: 'global' },
-      });
-      setItems(res.data.items || []);
+      const raw = await adminListOrgs({ q: debouncedQ, page, pageSize: 20 });
+      const list =
+        Array.isArray(raw?.items) ? raw.items :
+        Array.isArray(raw?.data) ? raw.data :
+        Array.isArray(raw?.orgs) ? raw.orgs :
+        Array.isArray(raw) ? raw : [];
+      setItems(list);
     } catch (e) {
       setError(true);
       toast({ title: 'Falha ao carregar organizações' });

--- a/frontend/src/pages/admin/OrgsListPage.jsx
+++ b/frontend/src/pages/admin/OrgsListPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import inboxApi from "../../api/inboxApi";
+import { adminListOrgs } from "../../api/inboxApi";
 import useActiveOrgGate from "../../hooks/useActiveOrgGate";
 import { useOrg } from "../../contexts/OrgContext.jsx";
 
@@ -15,15 +15,11 @@ export default function OrgsListPage({ minRole = "SuperAdmin" }) {
     let alive = true;
     (async () => {
       try {
-        // Admin endpoint em ESCOPO GLOBAL (sem X-Org-Id)
-        const res = await inboxApi.get("/admin/orgs", {
-          params: { q },
-          meta: { scope: "global" },
-        });
-        const raw = res?.data;
+        const raw = await adminListOrgs({ q });
         const items =
           Array.isArray(raw?.items) ? raw.items :
           Array.isArray(raw?.orgs) ? raw.orgs :
+          Array.isArray(raw?.data) ? raw.data :
           Array.isArray(raw) ? raw : [];
         if (!alive) return;
         setState({ loading: false, items, error: null });


### PR DESCRIPTION
## Summary
- update the admin org API modules in both frontend bundles to call `/api/orgs` via the shared HTTP client
- refresh inbox API helpers, mocks, and admin screens to reuse the new helpers without hardcoded `/admin/orgs`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a82714ec8327b16c4726ad38b99e