### PR TITLE
Add organization billing history endpoints and admin UI

### DIFF
--- a/backend/db/migrations/20251005_org_billing.sql
+++ b/backend/db/migrations/20251005_org_billing.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS invoices (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL,
+  external_id text,
+  status text NOT NULL DEFAULT 'open',
+  amount_cents integer NOT NULL DEFAULT 0,
+  currency text NOT NULL DEFAULT 'BRL',
+  due_date timestamptz,
+  paid_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS org_plan_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL,
+  event_type text NOT NULL,
+  data jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS org_credits_usage (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL,
+  meter text NOT NULL,
+  used integer NOT NULL DEFAULT 0,
+  period_start date NOT NULL,
+  period_end date NOT NULL
+);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,7 @@ import GovLogsPage from "./pages/marketing/GovLogsPage.jsx";
 import TelemetryPage from "./pages/governanca/TelemetryPage.jsx";
 import OrganizationsPage from "./pages/admin/OrganizationsPage.jsx";
 import OrgDetailsPage from "./pages/admin/OrgDetailsPage.jsx"; // ← detalhe da org
+import OrgBillingHistory from "./pages/admin/OrgBillingHistory.jsx";
 import PlansAdminPage from "./pages/admin/PlansAdminPage.jsx";
 import OrgPlanPage from "./pages/org/OrgPlanPage.jsx";
 
@@ -70,6 +71,10 @@ export default function App() {
             >
               <Route path="/admin/organizations" element={<OrganizationsPage />} />
               <Route path="/admin/organizations/:id" element={<OrgDetailsPage />} />{/* ← add */}
+              <Route
+                path="/admin/organizations/:id/history"
+                element={<OrgBillingHistory />}
+              />
               <Route path="/admin/plans" element={<PlansAdminPage />} />
             </Route>
 

--- a/frontend/src/api/admin/orgsApi.js
+++ b/frontend/src/api/admin/orgsApi.js
@@ -122,3 +122,17 @@ export async function deleteOrg(id) {
   if (!id) throw new Error("org_id_required");
   return requestJson("DELETE", `/orgs/${encodeURIComponent(id)}`);
 }
+
+// ===== CODEx: BEGIN admin org helpers =====
+export async function updateOrgStatus(orgId, status) {
+  if (!orgId) throw new Error("org_id_required");
+  return requestJson("PATCH", `/orgs/${encodeURIComponent(orgId)}/status`, {
+    body: { status },
+  });
+}
+
+export async function getOrgBillingHistory(orgId) {
+  if (!orgId) throw new Error("org_id_required");
+  return requestJson("GET", `/orgs/${encodeURIComponent(orgId)}/billing/history`);
+}
+// ===== CODEx: END admin org helpers =====

--- a/frontend/src/pages/admin/OrgBillingHistory.jsx
+++ b/frontend/src/pages/admin/OrgBillingHistory.jsx
@@ -1,0 +1,117 @@
+// ===== CODEx: BEGIN OrgBillingHistory.jsx =====
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { getOrgBillingHistory } from "@/api/admin/orgsApi";
+import { centsToBRL } from "@/api/inboxApi";
+
+export default function OrgBillingHistory() {
+  const { id } = useParams();
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState({ invoices: [], plan_events: [], credits: [] });
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const resp = await getOrgBillingHistory(id);
+        if (mounted) setData(resp || { invoices: [], plan_events: [], credits: [] });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, [id]);
+
+  if (loading) return <div className="p-4">Carregando…</div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Histórico da organização</h1>
+        <Link to="/admin/organizations" className="btn btn-ghost">Voltar</Link>
+      </div>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Pagamentos / Faturas</h2>
+        {data.invoices.length === 0 ? (
+          <div className="text-sm text-muted">Sem faturas cadastradas.</div>
+        ) : (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Nº</th>
+                <th>Status</th>
+                <th>Valor</th>
+                <th>Vencimento</th>
+                <th>Pago em</th>
+                <th>Criado em</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.invoices.map((f) => (
+                <tr key={f.id}>
+                  <td>{f.external_id || f.id.slice(0,8)}</td>
+                  <td>{f.status}</td>
+                  <td>{centsToBRL(f.amount_cents || 0)}</td>
+                  <td>{f.due_date ? new Date(f.due_date).toLocaleString() : "—"}</td>
+                  <td>{f.paid_at ? new Date(f.paid_at).toLocaleString() : "—"}</td>
+                  <td>{new Date(f.created_at).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Eventos de Plano</h2>
+        {data.plan_events.length === 0 ? (
+          <div className="text-sm text-muted">Sem eventos.</div>
+        ) : (
+          <ul className="space-y-2">
+            {data.plan_events.map((e) => (
+              <li key={e.id} className="p-3 rounded border">
+                <div className="text-sm">
+                  <b>{e.event_type}</b> — {new Date(e.created_at).toLocaleString()}
+                </div>
+                <pre className="mt-2 text-xs bg-muted p-2 rounded overflow-auto">
+                  {JSON.stringify(e.data, null, 2)}
+                </pre>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Consumo de Recursos</h2>
+        {data.credits.length === 0 ? (
+          <div className="text-sm text-muted">Sem registros.</div>
+        ) : (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Métrica</th>
+                <th>Usado</th>
+                <th>Início</th>
+                <th>Fim</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.credits.map((c) => (
+                <tr key={c.id}>
+                  <td>{c.meter}</td>
+                  <td>{c.used}</td>
+                  <td>{new Date(c.period_start).toLocaleDateString()}</td>
+                  <td>{new Date(c.period_end).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}
+// ===== CODEx: END OrgBillingHistory.jsx =====

--- a/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
+++ b/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   adminListOrgs,
   deleteAdminOrg,
@@ -230,6 +231,12 @@ export default function AdminOrganizationsPage() {
                   </td>
                   <td className="px-4 py-3 text-right text-sm">
                     <div className="flex justify-end gap-2">
+                      <Link
+                        to={`/admin/organizations/${org.id}/history`}
+                        className="rounded border border-blue-200 px-3 py-1 text-sm text-blue-600 transition hover:bg-blue-50"
+                      >
+                        Histórico
+                      </Link>
                       <button
                         type="button"
                         onClick={() => openEditModal(org)}


### PR DESCRIPTION
## Summary
- add admin endpoints to update organization plans/status and expose consolidated billing history, including a compatible migration for optional tables
- extend the admin org API helpers and edit modal to manage plan and status changes while fetching available plans
- add an organization billing history page, route, and entry point from the admin organizations list

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c1ece13c83279cc5f5a607152773