### PR TITLE
Enforce allowed organization statuses

### DIFF
--- a/backend/test/admin.orgs.list.spec.cjs
+++ b/backend/test/admin.orgs.list.spec.cjs
@@ -130,7 +130,7 @@ describe('Admin Orgs API', () => {
         expect(sql).toMatch(/ILIKE/);
         expect(sql).not.toMatch(/::uuid/i);
         expect(sql).toMatch(/LEFT\s+JOIN\s+public\.plans\s+p/i);
-        expect(params).toEqual(['inactive', '%Org%']);
+        expect(params).toEqual(['suspended', '%Org%']);
         return { rows: [] };
       }
       return { rows: [] };

--- a/frontend/src/api/__mocks__/inboxApi.js
+++ b/frontend/src/api/__mocks__/inboxApi.js
@@ -801,8 +801,22 @@ async function callAdminListOrgs(params = {}, options = {}) {
     : [];
   return list.map((org) => {
     const active = typeof org?.active === 'boolean' ? org.active : org?.status === 'active';
-    const statusValue = org?.status ?? (typeof active === 'boolean' ? (active ? 'active' : 'inactive') : undefined);
-    return { ...org, active, status: statusValue };
+    const statusNormalized = (() => {
+      if (org?.status != null) {
+        const normalized = String(org.status).trim().toLowerCase();
+        if (['active', 'trial', 'suspended', 'canceled'].includes(normalized)) {
+          return normalized;
+        }
+        if (normalized === 'inactive' || normalized === 'inativa') {
+          return 'suspended';
+        }
+      }
+      if (typeof active === 'boolean') {
+        return active ? 'active' : 'suspended';
+      }
+      return undefined;
+    })();
+    return { ...org, active, status: statusNormalized };
   });
 }
 

--- a/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
+++ b/frontend/src/pages/admin/organizations/AdminOrganizationsPage.jsx
@@ -7,11 +7,28 @@ import {
 } from '@/api/inboxApi';
 import AdminOrgEditModal from './AdminOrgEditModal.jsx';
 
+const STATUS_LABELS = {
+  active: 'Ativa',
+  trial: 'Em avaliação',
+  suspended: 'Suspensa',
+  canceled: 'Cancelada',
+};
+
 const STATUS_FILTERS = [
   { value: 'active', label: 'Ativas' },
-  { value: 'inactive', label: 'Inativas' },
+  { value: 'trial', label: 'Em avaliação' },
+  { value: 'suspended', label: 'Suspensas' },
+  { value: 'canceled', label: 'Canceladas' },
   { value: 'all', label: 'Todas' },
 ];
+
+function normalizeStatus(value) {
+  if (value == null) return 'active';
+  const normalized = String(value).trim().toLowerCase();
+  if (STATUS_LABELS[normalized]) return normalized;
+  if (normalized === 'inactive' || normalized === 'inativa') return 'suspended';
+  return 'active';
+}
 
 function useDebounced(value, delay = 300) {
   const [debounced, setDebounced] = useState(value);
@@ -28,29 +45,35 @@ function normalizeOrgData(org) {
       id: null,
       name: '',
       slug: '',
-      status: 'inactive',
+      status: 'active',
       plan: null,
     };
   }
-  const status = String(org.status ?? '').toLowerCase();
+  const status = normalizeStatus(org.status);
   return {
     id: org.id ?? null,
     name: org.name ?? org.razao_social ?? 'Sem nome',
     slug: org.slug ?? '',
-    status: status || 'inactive',
+    status,
     plan: org.plan ?? null,
     raw: org,
   };
 }
 
 function StatusBadge({ status }) {
-  const active = String(status).toLowerCase() === 'active';
+  const normalized = normalizeStatus(status);
+  const label = STATUS_LABELS[normalized] ?? 'Desconhecido';
+  const colorMap = {
+    active: 'bg-green-500',
+    trial: 'bg-blue-500',
+    suspended: 'bg-amber-500',
+    canceled: 'bg-red-500',
+  };
+  const color = colorMap[normalized] ?? 'bg-gray-300';
   return (
     <span className="inline-flex items-center gap-2">
-      <span
-        className={`inline-block h-2.5 w-2.5 rounded-full ${active ? 'bg-green-500' : 'bg-gray-300'}`}
-      />
-      {active ? 'Ativa' : 'Inativa'}
+      <span className={`inline-block h-2.5 w-2.5 rounded-full ${color}`} />
+      {label}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- restrict the admin organization form to the four database-supported status options and normalize legacy values
- validate organization status updates on the admin API before writing to the database and map legacy inputs
- refresh admin organization listings, mocks, and tests to reflect the new status vocabulary

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2f23325d883279baba0c97b9f8628