### PR TITLE
Handle phone uniqueness conflict in admin org patch

### DIFF
--- a/backend/routes/admin/orgById.js
+++ b/backend/routes/admin/orgById.js
@@ -219,6 +219,13 @@ router.patch("/", async (req, res, next) => {
 
     return res.json({ ok: true, org: rows[0] || null });
   } catch (e) {
+    if (e?.code === "23505" && /ux_org_phone_e164/i.test(e?.constraint || "")) {
+      return res.status(409).json({
+        error: "conflict",
+        field: "phone_e164",
+        message: "Este telefone já está em uso por outra organização.",
+      });
+    }
     if (e?.name === "ZodError") {
       return res.status(422).json({ error: "validation", issues: e.issues });
     }


### PR DESCRIPTION
## Summary
- return HTTP 409 when updating an organization fails due to duplicate phone numbers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5c1a012b88327aeb6b8fecfbd4fca